### PR TITLE
Setting locale for document generation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,16 @@
           iog-prelude
         ];
 
+        locales = {
+          LANG = "en_US.UTF-8";
+          LC_ALL = "en_US.UTF-8";
+          LOCALE_ARCHIVE = if pkgs.system == "x86_64-linux"
+                   then "${pkgs.glibcLocales}/lib/locale/locale-archive"
+                   else "";
+        };
+
         leiosSpec = pkgs.agdaPackages.mkDerivation {
+          inherit (locales) LANG LC_ALL LOCALE_ARCHIVE;
           pname = "leios-spec";
           version = "0.1";
           src = ./formal-spec;
@@ -57,6 +66,7 @@
         agdaWithPkgs = pkgs.agda.withPackages { pkgs = deps; ghc = pkgs.ghc; };
 
         leiosDocs = pkgs.stdenv.mkDerivation {
+          inherit (locales) LANG LC_ALL LOCALE_ARCHIVE;
           pname = "leios-docs";
           version = "0.1";
           src = ./formal-spec;


### PR DESCRIPTION
The PR fixes the following issue when running `leiosDocs` 
```
error: Cannot build '/nix/store/ij6ls4cpf3kdrfhfvdxnicyvp10ssprx-leios-docs-0.1.drv'.
       Reason: builder failed with exit code 42.
       Output paths:
         /nix/store/c967pm0c8qlnfk5rlns8p3jfnffd69w4-leios-docs-0.1
       Last 25 log lines:
       >    Checking CategoricalCrypto.Channel.Core (/build/formal-spec/CategoricalCrypto/Channel/Core.agda).
       >    Checking CategoricalCrypto.Channel.Selection (/build/formal-spec/CategoricalCrypto/Channel/Selection.agda).
       > /build/formal-spec/CategoricalCrypto/Channel/Selection.agda:156.11-19
       > <stdout>: commitBuffer: invalid argument (cannot encode character
       > '\9475')
       >
       > This error may be due to the use of a locale or code page that does not
       > support some character used in the program being type-checked.
       >
       > If it is, then one option is to use the option --transliterate, in which
       > case unsupported characters are (hopefully) replaced with something else,
       > perhaps question marks. However, that could make the output harder to
       > read.
       >
       > If you want to fix the problem "properly", then you could try one of the
       > following suggestions:
       >
       > * If you are using Windows, try switching to a different code page (for
       >   instance by running the command 'CHCP 65001').
       >
       > * If you are using a Unix-like system, try using a different locale. The
       >   installed locales are perhaps printed by the command 'locale -a'. If
       >   you have a UTF-8 locale installed (for instance sv_SE.UTF-8), then you
       >   can perhaps make Agda use this locale by running something like
       >   'LC_ALL=sv_SE.UTF-8 agda <...>'.
       For full logs, run:
         nix log /nix/store/ij6ls4cpf3kdrfhfvdxnicyvp10ssprx-leios-docs-0.1.drv
Error: Process completed with exit code 1.
```