### PR TITLE
Removed disclaimer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-> [!CAUTION]
-> 
-> **Important Disclaimer & Acceptance of Risk**
-> 
-> This is a proof-of-concept implementation in its very early stage and is mostly experimental and exploratory. This code is provided "as is" for research and educational purposes only.  All contributions and feedbacks are welcome. **By using this code, you acknowledge and accept all associated risks, and our company disclaims any liability for damages or losses.**
-
 # Ouroboros Leios formal specification
 
 This repository is to define a formal specification of the Ouroboros Leios protocol.


### PR DESCRIPTION
The disclaimer is no longer accurate as
* The repo has been stripped down to only contain Linear Leios
* The specification has evolved an is no longer considered early stage
* It is no longer proof of concept