### PR TITLE
State & prove liveness

### DIFF
--- a/formal-spec/Blockchain/IsBlockchain.agda
+++ b/formal-spec/Blockchain/IsBlockchain.agda
@@ -11,12 +11,10 @@ open import CategoricalCrypto
 -- `n` is the number of nodes.
 module Blockchain.IsBlockchain (Participant : Type) where
 
--- | Type of things we can query from a honest node.
 data BlockChainInfo (Block : Type) : Type where
   Chain : BlockChainInfo Block
   Slot  : BlockChainInfo Block
 
--- | Type for responses given a specific query.
 bciQueryType : ∀ {Block : Type} → BlockChainInfo Block → Type
 bciQueryType {Block = Block} Chain = List Block
 bciQueryType                 Slot  = ℕ

--- a/formal-spec/Blockchain/IsBlockchain.agda
+++ b/formal-spec/Blockchain/IsBlockchain.agda
@@ -9,21 +9,39 @@ open import CategoricalCrypto
 -- Parameterised over the block type and the type of participants (producers).
 -- At use sites, `Participant` is typically instantiated to `Fin n` where
 -- `n` is the number of nodes.
-module Blockchain.IsBlockchain (Block : Type) (Participant : Type) where
+module Blockchain.IsBlockchain (Participant : Type) where
 
--- | Type of things we can query from a honest node
-data BlockChainInfo : Type where
-  Chain : BlockChainInfo
-  Slot  : BlockChainInfo
+-- | Type of things we can query from a honest node.
+data BlockChainInfo (Block : Type) : Type where
+  Chain : BlockChainInfo Block
+  Slot  : BlockChainInfo Block
 
--- | Type for responses given a specific query
-bciQueryType : BlockChainInfo → Type
-bciQueryType Chain = List Block
-bciQueryType Slot  = ℕ
+-- | Type for responses given a specific query.
+bciQueryType : ∀ {Block : Type} → BlockChainInfo Block → Type
+bciQueryType {Block = Block} Chain = List Block
+bciQueryType                 Slot  = ℕ
 
-record IsBlockchain {A B : Channel} (m : Machine A B) : Type₂ where
+record IsBlockchain (Block : Type) {A B : Channel} (m : Machine A B) : Type₂ where
   field
-    isConstrained : IsConstrained m bciQueryType
+    isConstrained : IsConstrained m (bciQueryType {Block})
     isPure        : IsPure isConstrained
     producer      : Block → Participant
     slotOf        : Block → ℕ
+
+-- | Compatibility witness relating two `IsBlockchain` instances over the same
+-- participant type but different block types.
+record IsBlockchain-compatible
+  {BlockBase BlockExt : Type}
+  {Abase Bbase : Channel} {mbase : Machine Abase Bbase}
+  {Aext  Bext  : Channel} {mext  : Machine Aext  Bext}
+  (base : IsBlockchain BlockBase mbase)
+  (ext  : IsBlockchain BlockExt  mext)
+  : Type where
+  private
+    module IB-base = IsBlockchain base
+    module IB-ext  = IsBlockchain ext
+  field
+    getBaseBlock      : BlockExt → BlockBase
+    getBaseBlock-inj  : Injective _≡_ _≡_ getBaseBlock
+    producer-compat   : ∀ b → IB-ext.producer b ≡ IB-base.producer (getBaseBlock b)
+    slotOf-compat     : ∀ b → IB-ext.slotOf   b ≡ IB-base.slotOf   (getBaseBlock b)

--- a/formal-spec/Blockchain/IsBlockchain.agda
+++ b/formal-spec/Blockchain/IsBlockchain.agda
@@ -3,8 +3,7 @@
 open import Leios.Prelude
 open import CategoricalCrypto
 
--- | Generic "the machine answers blockchain queries and blocks carry
--- producer/slot metadata" witness.
+-- | Typeclass for machines that behave like a blockchain
 --
 -- Parameterised over the type of participants (producers).  At use sites,
 -- `Participant` is typically instantiated to `Fin n` where `n` is the number

--- a/formal-spec/Blockchain/IsBlockchain.agda
+++ b/formal-spec/Blockchain/IsBlockchain.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --safe #-}
+
+open import Leios.Prelude
+open import CategoricalCrypto
+
+-- | Generic "the machine answers blockchain queries and blocks carry
+-- producer/slot metadata" witness.
+--
+-- Parameterised over the block type and the type of participants (producers).
+-- At use sites, `Participant` is typically instantiated to `Fin n` where
+-- `n` is the number of nodes.
+module Blockchain.IsBlockchain (Block : Type) (Participant : Type) where
+
+-- | Type of things we can query from a honest node
+data BlockChainInfo : Type where
+  Chain : BlockChainInfo
+  Slot  : BlockChainInfo
+
+-- | Type for responses given a specific query
+bciQueryType : BlockChainInfo → Type
+bciQueryType Chain = List Block
+bciQueryType Slot  = ℕ
+
+record IsBlockchain {A B : Channel} (m : Machine A B) : Type₂ where
+  field
+    isConstrained : IsConstrained m bciQueryType
+    isPure        : IsPure isConstrained
+    producer      : Block → Participant
+    slotOf        : Block → ℕ

--- a/formal-spec/Blockchain/IsBlockchain.agda
+++ b/formal-spec/Blockchain/IsBlockchain.agda
@@ -6,9 +6,9 @@ open import CategoricalCrypto
 -- | Generic "the machine answers blockchain queries and blocks carry
 -- producer/slot metadata" witness.
 --
--- Parameterised over the block type and the type of participants (producers).
--- At use sites, `Participant` is typically instantiated to `Fin n` where
--- `n` is the number of nodes.
+-- Parameterised over the type of participants (producers).  At use sites,
+-- `Participant` is typically instantiated to `Fin n` where `n` is the number
+-- of nodes.
 module Blockchain.IsBlockchain (Participant : Type) where
 
 data BlockChainInfo (Block : Type) : Type where
@@ -25,21 +25,3 @@ record IsBlockchain (Block : Type) {A B : Channel} (m : Machine A B) : Type₂ w
     isPure        : IsPure isConstrained
     producer      : Block → Participant
     slotOf        : Block → ℕ
-
--- | Compatibility witness relating two `IsBlockchain` instances over the same
--- participant type but different block types.
-record IsBlockchain-compatible
-  {BlockBase BlockExt : Type}
-  {Abase Bbase : Channel} {mbase : Machine Abase Bbase}
-  {Aext  Bext  : Channel} {mext  : Machine Aext  Bext}
-  (base : IsBlockchain BlockBase mbase)
-  (ext  : IsBlockchain BlockExt  mext)
-  : Type where
-  private
-    module IB-base = IsBlockchain base
-    module IB-ext  = IsBlockchain ext
-  field
-    getBaseBlock      : BlockExt → BlockBase
-    getBaseBlock-inj  : Injective _≡_ _≡_ getBaseBlock
-    producer-compat   : ∀ b → IB-ext.producer b ≡ IB-base.producer (getBaseBlock b)
-    slotOf-compat     : ∀ b → IB-ext.slotOf   b ≡ IB-base.slotOf   (getBaseBlock b)

--- a/formal-spec/Blockchain/Liveness.agda
+++ b/formal-spec/Blockchain/Liveness.agda
@@ -1,0 +1,75 @@
+{-# OPTIONS --safe #-}
+
+open import Leios.Prelude hiding (id; _⊗_)
+
+open import CategoricalCrypto hiding (id; _∘_)
+
+open import Blockchain.Safety using (Safety)
+
+import Data.Integer as ℤ
+import Data.Rational as ℚ
+open ℚ using (ℚ)
+
+module Blockchain.Liveness
+  (Block : Type)
+  (S     : Safety Block)
+  where
+
+open Safety S
+
+private
+  ℕ→ℚ : ℕ → ℚ
+  ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
+
+-- Additional structure needed for liveness: every block has a producer
+-- (a party) and a slot number. A block is honest iff its producer is
+-- an honest party.
+record Liveness : Type where
+  field
+    producer : Block → Fin n
+    slotOf   : Block → ℕ
+
+  isHonestBlock : Block → Type
+  isHonestBlock b = producer b ∈ honest-nodes
+
+  -- --------------------------------------------------------------------
+  -- (HCG) Honest Chain Growth
+  --
+  -- For every honest block `b` in an honest party's chain, the number
+  -- of blocks that follow `b` is at least τ · (currentSlot ∸ slotOf b).
+  -- The genesis block (assumed honest) makes this imply a bound on
+  -- absolute chain length vs. current slot.
+
+  hcgState : {A : Channel} → ℚ → (E : Environment A)
+           → Machine.State (protocol E) → Type
+  hcgState τ E S₀ =
+      {p : Fin n} (hp : p ∈ honest-nodes)
+      {pref suff : List Block} {b : Block}
+    → getChain E S₀ hp ≡ pref ++ (b ∷ suff)
+    → isHonestBlock b
+    → τ ℚ.* ℕ→ℚ (getSlot E S₀ hp ∸ slotOf b) ℚ.≤ ℕ→ℚ (length suff)
+
+  hcg : ℚ → Type₁
+  hcg τ = ∀ {A} (E : Environment A)
+        → Invariant (protocol E) (hcgState τ E)
+
+  -- --------------------------------------------------------------------
+  -- (∃CQ) Existential Chain Quality
+  --
+  -- In every honest party's chain, the suffix of blocks whose slot is
+  -- within the last T slots contains at least one honest block. The
+  -- assumed honest genesis block guarantees this list is non-empty
+  -- during startup.
+
+  recent : ℕ → ℕ → List Block → List Block
+  recent T s = filter (λ b → slotOf b + T ≥ s)
+
+  ∃cqState : {A : Channel} → ℕ → (E : Environment A)
+           → Machine.State (protocol E) → Type
+  ∃cqState T E S₀ =
+      {p : Fin n} (hp : p ∈ honest-nodes)
+    → Any.Any isHonestBlock (recent T (getSlot E S₀ hp) (getChain E S₀ hp))
+
+  ∃cq : ℕ → Type₁
+  ∃cq T = ∀ {A} (E : Environment A)
+        → Invariant (protocol E) (∃cqState T E)

--- a/formal-spec/Blockchain/Liveness.agda
+++ b/formal-spec/Blockchain/Liveness.agda
@@ -40,8 +40,7 @@ record Liveness : Type where
   -- The genesis block (assumed honest) makes this imply a bound on
   -- absolute chain length vs. current slot.
 
-  hcgState : {A : Channel} → ℚ → (E : Environment A)
-           → Machine.State (protocol E) → Type
+  hcgState : {A : Channel} → ℚ → (E : Environment A) → Machine.State (protocol E) → Type
   hcgState τ E S₀ =
       {p : Fin n} (hp : p ∈ honest-nodes)
       {pref suff : List Block} {b : Block}
@@ -50,8 +49,7 @@ record Liveness : Type where
     → τ ℚ.* ℕ→ℚ (getSlot E S₀ hp ∸ slotOf b) ℚ.≤ ℕ→ℚ (length suff)
 
   hcg : ℚ → Type₁
-  hcg τ = ∀ {A} (E : Environment A)
-        → Invariant (protocol E) (hcgState τ E)
+  hcg τ = ∀ {A} (E : Environment A) → Invariant (protocol E) (hcgState τ E)
 
   -- --------------------------------------------------------------------
   -- (∃CQ) Existential Chain Quality
@@ -64,12 +62,10 @@ record Liveness : Type where
   recent : ℕ → ℕ → List Block → List Block
   recent T s = filter (λ b → slotOf b + T ≥ s)
 
-  ∃cqState : {A : Channel} → ℕ → (E : Environment A)
-           → Machine.State (protocol E) → Type
+  ∃cqState : {A : Channel} → ℕ → (E : Environment A) → Machine.State (protocol E) → Type
   ∃cqState T E S₀ =
       {p : Fin n} (hp : p ∈ honest-nodes)
     → Any.Any isHonestBlock (recent T (getSlot E S₀ hp) (getChain E S₀ hp))
 
   ∃cq : ℕ → Type₁
-  ∃cq T = ∀ {A} (E : Environment A)
-        → Invariant (protocol E) (∃cqState T E)
+  ∃cq T = ∀ {A} (E : Environment A) → Invariant (protocol E) (∃cqState T E)

--- a/formal-spec/Blockchain/Liveness.agda
+++ b/formal-spec/Blockchain/Liveness.agda
@@ -17,12 +17,9 @@ module Blockchain.Liveness
 
 open Safety S
 
-private
-  ℕ→ℚ : ℕ → ℚ
-  ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
+ℕ→ℚ : ℕ → ℚ
+ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
 
--- A block is honest iff its producer (from the `IsBlockchain` witness) is
--- an honest party.
 isHonestBlock : Block → Type
 isHonestBlock b = producer b ∈ honest-nodes
 
@@ -31,8 +28,6 @@ isHonestBlock b = producer b ∈ honest-nodes
 --
 -- For every honest block `b` in an honest party's chain, the number
 -- of blocks that follow `b` is at least τ · (currentSlot ∸ slotOf b).
--- The genesis block (assumed honest) makes this imply a bound on
--- absolute chain length vs. current slot.
 
 hcgState : {A : Channel} → ℚ → (E : Environment A) → Machine.State (protocol E) → Type
 hcgState τ E S₀ =
@@ -49,9 +44,7 @@ hcg τ = ∀ {A} (E : Environment A) → Invariant (protocol E) (hcgState τ E)
 -- (∃CQ) Existential Chain Quality
 --
 -- In every honest party's chain, the suffix of blocks whose slot is
--- within the last T slots contains at least one honest block. The
--- assumed honest genesis block guarantees this list is non-empty
--- during startup.
+-- within the last T slots contains at least one honest block.
 
 recent : ℕ → ℕ → List Block → List Block
 recent T s = filter (λ b → slotOf b + T ≥ s)

--- a/formal-spec/Blockchain/Liveness.agda
+++ b/formal-spec/Blockchain/Liveness.agda
@@ -4,7 +4,7 @@ open import Leios.Prelude hiding (id; _⊗_)
 
 open import CategoricalCrypto hiding (id; _∘_)
 
-open import Blockchain.Safety using (Safety)
+open import Blockchain.Safety using (Deployment)
 
 import Data.Integer as ℤ
 import Data.Rational as ℚ
@@ -12,10 +12,10 @@ open ℚ using (ℚ)
 
 module Blockchain.Liveness
   (Block : Type)
-  (S     : Safety Block)
+  (S     : Deployment Block)
   where
 
-open Safety S
+open Deployment S
 
 ℕ→ℚ : ℕ → ℚ
 ℕ→ℚ n = (ℤ.+ n) ℚ./ 1

--- a/formal-spec/Blockchain/Liveness.agda
+++ b/formal-spec/Blockchain/Liveness.agda
@@ -21,51 +21,45 @@ private
   ℕ→ℚ : ℕ → ℚ
   ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
 
--- Additional structure needed for liveness: every block has a producer
--- (a party) and a slot number. A block is honest iff its producer is
+-- A block is honest iff its producer (from the `IsBlockchain` witness) is
 -- an honest party.
-record Liveness : Type where
-  field
-    producer : Block → Fin n
-    slotOf   : Block → ℕ
+isHonestBlock : Block → Type
+isHonestBlock b = producer b ∈ honest-nodes
 
-  isHonestBlock : Block → Type
-  isHonestBlock b = producer b ∈ honest-nodes
+-- --------------------------------------------------------------------
+-- (HCG) Honest Chain Growth
+--
+-- For every honest block `b` in an honest party's chain, the number
+-- of blocks that follow `b` is at least τ · (currentSlot ∸ slotOf b).
+-- The genesis block (assumed honest) makes this imply a bound on
+-- absolute chain length vs. current slot.
 
-  -- --------------------------------------------------------------------
-  -- (HCG) Honest Chain Growth
-  --
-  -- For every honest block `b` in an honest party's chain, the number
-  -- of blocks that follow `b` is at least τ · (currentSlot ∸ slotOf b).
-  -- The genesis block (assumed honest) makes this imply a bound on
-  -- absolute chain length vs. current slot.
+hcgState : {A : Channel} → ℚ → (E : Environment A) → Machine.State (protocol E) → Type
+hcgState τ E S₀ =
+    {p : Fin n} (hp : p ∈ honest-nodes)
+    {pref suff : List Block} {b : Block}
+  → getChain E S₀ hp ≡ pref ++ (b ∷ suff)
+  → isHonestBlock b
+  → τ ℚ.* ℕ→ℚ (getSlot E S₀ hp ∸ slotOf b) ℚ.≤ ℕ→ℚ (length suff)
 
-  hcgState : {A : Channel} → ℚ → (E : Environment A) → Machine.State (protocol E) → Type
-  hcgState τ E S₀ =
-      {p : Fin n} (hp : p ∈ honest-nodes)
-      {pref suff : List Block} {b : Block}
-    → getChain E S₀ hp ≡ pref ++ (b ∷ suff)
-    → isHonestBlock b
-    → τ ℚ.* ℕ→ℚ (getSlot E S₀ hp ∸ slotOf b) ℚ.≤ ℕ→ℚ (length suff)
+hcg : ℚ → Type₁
+hcg τ = ∀ {A} (E : Environment A) → Invariant (protocol E) (hcgState τ E)
 
-  hcg : ℚ → Type₁
-  hcg τ = ∀ {A} (E : Environment A) → Invariant (protocol E) (hcgState τ E)
+-- --------------------------------------------------------------------
+-- (∃CQ) Existential Chain Quality
+--
+-- In every honest party's chain, the suffix of blocks whose slot is
+-- within the last T slots contains at least one honest block. The
+-- assumed honest genesis block guarantees this list is non-empty
+-- during startup.
 
-  -- --------------------------------------------------------------------
-  -- (∃CQ) Existential Chain Quality
-  --
-  -- In every honest party's chain, the suffix of blocks whose slot is
-  -- within the last T slots contains at least one honest block. The
-  -- assumed honest genesis block guarantees this list is non-empty
-  -- during startup.
+recent : ℕ → ℕ → List Block → List Block
+recent T s = filter (λ b → slotOf b + T ≥ s)
 
-  recent : ℕ → ℕ → List Block → List Block
-  recent T s = filter (λ b → slotOf b + T ≥ s)
+∃cqState : {A : Channel} → ℕ → (E : Environment A) → Machine.State (protocol E) → Type
+∃cqState T E S₀ =
+    {p : Fin n} (hp : p ∈ honest-nodes)
+  → Any.Any isHonestBlock (recent T (getSlot E S₀ hp) (getChain E S₀ hp))
 
-  ∃cqState : {A : Channel} → ℕ → (E : Environment A) → Machine.State (protocol E) → Type
-  ∃cqState T E S₀ =
-      {p : Fin n} (hp : p ∈ honest-nodes)
-    → Any.Any isHonestBlock (recent T (getSlot E S₀ hp) (getChain E S₀ hp))
-
-  ∃cq : ℕ → Type₁
-  ∃cq T = ∀ {A} (E : Environment A) → Invariant (protocol E) (∃cqState T E)
+∃cq : ℕ → Type₁
+∃cq T = ∀ {A} (E : Environment A) → Invariant (protocol E) (∃cqState T E)

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -3,13 +3,11 @@
 open import Leios.Prelude hiding (id; _⊗_; _∘_)
 open import Blockchain.Safety
 import Blockchain.IsBlockchain as IsBC
-open import Blockchain.Liveness
+import Blockchain.Liveness
 open import Leios.ChannelCat
 
 open import CategoricalCrypto hiding (id)
-import CategoricalCrypto as CC
 
-import Data.Integer as ℤ
 import Data.Rational as ℚ
 import Data.Rational.Properties as ℚP
 open ℚ using (ℚ)
@@ -21,11 +19,9 @@ open import Relation.Unary using (Decidable)
 
 -- | Generic liveness transfer.
 --
--- Given the same ingredients as `Blockchain.Safety.Transfer` (an extended
--- blockchain spec `ext`, a chain-projection `getBaseBlock` into a base
--- blockchain spec, and an honest upper layer `ext-spec`), plus compatibility
--- witnesses that `producer` and `slotOf` (now fields of `IsBlockchain`) agree
--- across the projection, HCG and ∃CQ transfer from base to ext.
+-- Given the same ingredients as `Blockchain.Safety.Transfer` plus an
+-- `IsBlockchain-compatible` witness that the ext spec's `producer`/`slotOf`
+-- factor through `getBaseBlock`, HCG and ∃CQ transfer from base to ext.
 module Blockchain.Liveness.Transfer
   {BlockExt BlockBase   : Type}
   (ext                  : Safety BlockExt)
@@ -52,9 +48,6 @@ module Ext  = Tr.Ext
 module Base = Tr.Base
 
 private
-  ℕ→ℚ : ℕ → ℚ
-  ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
-
   -- Generic lemma: filtering after mapping equals mapping after filtering
   -- with the pulled-back predicate.
   filter-map : ∀ {A B : Type} {P : B → Type} (P? : Decidable P) (f : A → B)
@@ -90,6 +83,7 @@ private
 
 module BL = Blockchain.Liveness BlockBase Tr.base
 module EL = Blockchain.Liveness BlockExt   ext
+open BL using (ℕ→ℚ)
 
 module Main (single-protocol-≡ : ∀ p
                                → idᴷ ∘ᴷ Ext.all-nodes p

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -12,9 +12,10 @@ import Data.Integer as ℤ
 import Data.Rational as ℚ
 open ℚ using (ℚ)
 
-open import Data.List.Properties using (∷-injective; map-++; length-map; filter-accept; filter-reject)
+open import Data.List.Properties using (∷-injective; map-++; length-map)
 import Data.List.Relation.Unary.Any.Properties as AnyP
 import Data.List as L
+open import Relation.Unary using (Decidable)
 
 -- | Generic liveness transfer.
 --
@@ -52,9 +53,20 @@ private
   ℕ→ℚ : ℕ → ℚ
   ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
 
+  -- Generic lemma: filtering after mapping equals mapping after filtering
+  -- with the pulled-back predicate. Proof is the standard induction on
+  -- `xs` with case analysis on `P? (f x)`.
+  filter-map : ∀ {A B : Type} {P : B → Type} (P? : Decidable P) (f : A → B)
+               (xs : List A)
+             → L.filter P? (L.map f xs) ≡ L.map f (L.filter (λ x → P? (f x)) xs)
+  filter-map P? f [] = refl
+  filter-map P? f (x ∷ xs) with P? (f x)
+  ... | yes _ = cong (f x ∷_) (filter-map P? f xs)
+  ... | no  _ = filter-map P? f xs
+
 -- A splitting of `map f l` lifts to a splitting of `l`.
 private
-  map-split : ∀ {A B} {f : A → B} (l : List A) (pref : List B) (b : B) (suff : List B)
+  map-split : ∀ {A B : Type} {f : A → B} (l : List A) (pref : List B) (b : B) (suff : List B)
     → map f l ≡ pref ++ b ∷ suff
     → Σ[ pref' ∈ List A ] Σ[ b' ∈ A ] Σ[ suff' ∈ List A ]
          (l ≡ pref' ++ b' ∷ suff')
@@ -107,31 +119,12 @@ module _ (baseLiv : BL.Liveness) where
       → Base.getSlot (transEnv E) (transState E s) p-honest
       ≡ Ext.getSlot E s p-honest
 
-    -- `recent` commutes with `map getBaseBlock`. The predicate
-    -- `λ b → slotOf b + T ≥ s` is decidable on ℕ and the decidability
-    -- instance used on the ext and base sides agrees up to `getBaseBlock`,
-    -- since `LE.slotOf` is defined as `LB.slotOf ∘ getBaseBlock`.
+    -- `recent` commutes with `map getBaseBlock`. Follows from the generic
+    -- `filter-map` lemma together with the fact that `LE.slotOf = LB.slotOf ∘ getBaseBlock`
+    -- (which holds by definition of `extLiv`).
     recent-map : ∀ T s (l : List BlockExt)
       → LB.recent T s (map getBaseBlock l) ≡ map getBaseBlock (LE.recent T s l)
-    recent-map T s [] = refl
-    recent-map T s (x ∷ xs)
-      with ¿ LB.slotOf (getBaseBlock x) + T ≥ s ¿
-    ... | yes p =
-      let lhs-eq : LB.recent T s (getBaseBlock x ∷ map getBaseBlock xs)
-                 ≡ getBaseBlock x ∷ LB.recent T s (map getBaseBlock xs)
-          lhs-eq = filter-accept ¿ _ ¿¹ p
-          rhs-eq : LE.recent T s (x ∷ xs) ≡ x ∷ LE.recent T s xs
-          rhs-eq = filter-accept ¿ _ ¿¹ p
-      in trans lhs-eq
-               (trans (cong (getBaseBlock x ∷_) (recent-map T s xs))
-                      (cong (map getBaseBlock) (sym rhs-eq)))
-    ... | no ¬p =
-      let lhs-eq : LB.recent T s (getBaseBlock x ∷ map getBaseBlock xs)
-                 ≡ LB.recent T s (map getBaseBlock xs)
-          lhs-eq = filter-reject ¿ _ ¿¹ ¬p
-          rhs-eq : LE.recent T s (x ∷ xs) ≡ LE.recent T s xs
-          rhs-eq = filter-reject ¿ _ ¿¹ ¬p
-      in trans lhs-eq (trans (recent-map T s xs) (cong (map getBaseBlock) (sym rhs-eq)))
+    recent-map T s l = filter-map ¿ _ ¿¹ getBaseBlock l
 
     module _ {A : Channel} (E : Ext.Environment A)
              (CL : ChainLemma-ty E) (SL : SlotLemma-ty E)
@@ -143,50 +136,68 @@ module _ (baseLiv : BL.Liveness) where
         → LE.hcgState τ E s
         → LB.hcgState τ (transEnv E) (transState E s)
       hcgState-ext⇒base τ ext-hcg-s {p} hp {pref} {suff} {b} base-eq honest-b =
-        let mapped-eq : map getBaseBlock (Ext.getChain E s hp) ≡ pref ++ b ∷ suff
-            mapped-eq = trans (sym (CL hp)) base-eq
-        in case map-split (Ext.getChain E s hp) pref b suff mapped-eq of λ where
+        case map-split (Ext.getChain E s hp) pref b suff
+               (trans (sym (CL hp)) base-eq) of λ where
           (pref' , b' , suff' , ext-eq , _ , fb'≡ , msuff≡) →
-            let honest-b' : LE.isHonestBlock b'
-                honest-b' = subst (λ x → LB.producer x ∈ Ext.honest-nodes)
+            H.result pref' b' suff' ext-eq fb'≡ msuff≡
+        where
+          -- All the per-branch reasoning lives in a helper module so each
+          -- step's type signature is elaborated exactly once with the
+          -- destructured arguments as module parameters, instead of being
+          -- re-elaborated inside a nested `let`.
+          module H (pref' : List BlockExt) (b' : BlockExt) (suff' : List BlockExt)
+                   (ext-eq  : Ext.getChain E s hp ≡ pref' ++ b' ∷ suff')
+                   (fb'≡    : getBaseBlock b' ≡ b)
+                   (msuff≡  : map getBaseBlock suff' ≡ suff) where
+
+            honest-b' : LE.isHonestBlock b'
+            honest-b' = subst (λ x → LB.producer x ∈ Ext.honest-nodes)
                               (sym fb'≡) honest-b
 
-                ext-bound : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b')
-                          ℚ.≤ ℕ→ℚ (length suff')
-                ext-bound = ext-hcg-s hp ext-eq honest-b'
-
-                slot-eq : Ext.getSlot E s hp
-                        ≡ Base.getSlot (transEnv E) (transState E s) hp
-                slot-eq = sym (SL hp)
-
-                slotOf-eq : LE.slotOf b' ≡ LB.slotOf b
-                slotOf-eq = cong LB.slotOf fb'≡
-
-                length-eq : length suff' ≡ length suff
-                length-eq = trans (sym (length-map getBaseBlock suff'))
-                                  (cong length msuff≡)
-
-                step₁ : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LB.slotOf b)
+            ext-bound : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b')
                       ℚ.≤ ℕ→ℚ (length suff')
-                step₁ = subst (λ y → τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ y)
-                                   ℚ.≤ ℕ→ℚ (length suff'))
-                              slotOf-eq ext-bound
+            ext-bound = ext-hcg-s hp ext-eq honest-b'
 
-                step₂ : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
-                                    ∸ LB.slotOf b)
-                      ℚ.≤ ℕ→ℚ (length suff')
-                step₂ = subst (λ x → τ ℚ.* ℕ→ℚ (x ∸ LB.slotOf b)
-                                   ℚ.≤ ℕ→ℚ (length suff'))
-                              slot-eq step₁
-            in subst (λ y → τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
-                                        ∸ LB.slotOf b) ℚ.≤ ℕ→ℚ y)
-                     length-eq step₂
+            slot-eq : Ext.getSlot E s hp
+                    ≡ Base.getSlot (transEnv E) (transState E s) hp
+            slot-eq = sym (SL hp)
+
+            slotOf-eq : LE.slotOf b' ≡ LB.slotOf b
+            slotOf-eq = cong LB.slotOf fb'≡
+
+            length-eq : length suff' ≡ length suff
+            length-eq = trans (sym (length-map getBaseBlock suff'))
+                              (cong length msuff≡)
+
+            step₁ : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LB.slotOf b)
+                  ℚ.≤ ℕ→ℚ (length suff')
+            step₁ = subst (λ y → τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ y)
+                               ℚ.≤ ℕ→ℚ (length suff'))
+                          slotOf-eq ext-bound
+
+            step₂ : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                                ∸ LB.slotOf b)
+                  ℚ.≤ ℕ→ℚ (length suff')
+            step₂ = subst (λ x → τ ℚ.* ℕ→ℚ (x ∸ LB.slotOf b)
+                               ℚ.≤ ℕ→ℚ (length suff'))
+                          slot-eq step₁
+
+            result : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                                 ∸ LB.slotOf b)
+                   ℚ.≤ ℕ→ℚ (length suff)
+            result = subst (λ y → τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                                               ∸ LB.slotOf b) ℚ.≤ ℕ→ℚ y)
+                           length-eq step₂
 
       hcgState-base⇒ext : ∀ τ
         → LB.hcgState τ (transEnv E) (transState E s)
         → LE.hcgState τ E s
       hcgState-base⇒ext τ base-hcg-s {p} hp {pref} {suff} {b} ext-eq honest-b =
-        let base-eq : Base.getChain (transEnv E) (transState E s) hp
+        H.result
+        where
+          module H where
+
+            base-eq : Base.getChain (transEnv E) (transState E s) hp
                     ≡ map getBaseBlock pref ++ getBaseBlock b ∷ map getBaseBlock suff
             base-eq = trans (CL hp)
                             (trans (cong (map getBaseBlock) ext-eq)
@@ -203,8 +214,11 @@ module _ (baseLiv : BL.Liveness) where
 
             length-eq : length (map getBaseBlock suff) ≡ length suff
             length-eq = length-map getBaseBlock suff
-        in subst₂ (λ x y → τ ℚ.* ℕ→ℚ (x ∸ LE.slotOf b) ℚ.≤ ℕ→ℚ y)
-                  slot-eq length-eq bound
+
+            result : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b)
+                   ℚ.≤ ℕ→ℚ (length suff)
+            result = subst₂ (λ x y → τ ℚ.* ℕ→ℚ (x ∸ LE.slotOf b) ℚ.≤ ℕ→ℚ y)
+                            slot-eq length-eq bound
 
       -- ∃CQ -----------------------------------------------------------------
 
@@ -212,27 +226,15 @@ module _ (baseLiv : BL.Liveness) where
         → LE.∃cqState T E s
         → LB.∃cqState T (transEnv E) (transState E s)
       ∃cqState-ext⇒base T ext-∃cq-s {p} hp =
-        let ext-any : Any.Any LE.isHonestBlock
-                        (LE.recent T (Ext.getSlot E s hp) (Ext.getChain E s hp))
-            ext-any = ext-∃cq-s hp
+        let ext-any = ext-∃cq-s hp
 
-            mapped-any : Any.Any LE.isHonestBlock
-                          (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
-                                       (Ext.getChain E s hp))
             mapped-any = subst (λ x → Any.Any LE.isHonestBlock
                                          (LE.recent T x (Ext.getChain E s hp)))
                                (sym (SL hp)) ext-any
 
             -- Push `map getBaseBlock` inside `recent` via `recent-map`.
-            any-on-map : Any.Any LB.isHonestBlock
-                          (map getBaseBlock
-                            (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
-                                        (Ext.getChain E s hp)))
             any-on-map = AnyP.map⁺ mapped-any
 
-            any-base-recent : Any.Any LB.isHonestBlock
-                                (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp)
-                                             (map getBaseBlock (Ext.getChain E s hp)))
             any-base-recent =
               subst (Any.Any LB.isHonestBlock)
                     (sym (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
@@ -248,33 +250,20 @@ module _ (baseLiv : BL.Liveness) where
         → LB.∃cqState T (transEnv E) (transState E s)
         → LE.∃cqState T E s
       ∃cqState-base⇒ext T base-∃cq-s {p} hp =
-        let base-any : Any.Any LB.isHonestBlock
-                        (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp)
-                                     (Base.getChain (transEnv E) (transState E s) hp))
-            base-any = base-∃cq-s hp
+        let base-any = base-∃cq-s hp
 
             -- Rewrite base chain → map getBaseBlock of ext chain.
-            step₁ : Any.Any LB.isHonestBlock
-                     (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp)
-                                  (map getBaseBlock (Ext.getChain E s hp)))
             step₁ = subst (λ cs → Any.Any LB.isHonestBlock
                                     (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp) cs))
                           (CL hp) base-any
 
             -- Pull `map getBaseBlock` out of `recent`.
-            step₂ : Any.Any LB.isHonestBlock
-                     (map getBaseBlock
-                       (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
-                                   (Ext.getChain E s hp)))
             step₂ = subst (Any.Any LB.isHonestBlock)
                           (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
                                        (Ext.getChain E s hp))
                           step₁
 
             -- Any (P ∘ f) on original list.
-            step₃ : Any.Any LE.isHonestBlock
-                     (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
-                                 (Ext.getChain E s hp))
             step₃ = AnyP.map⁻ step₂
         in subst (λ x → Any.Any LE.isHonestBlock
                            (LE.recent T x (Ext.getChain E s hp)))

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -10,6 +10,7 @@ import CategoricalCrypto as CC
 
 import Data.Integer as ℤ
 import Data.Rational as ℚ
+import Data.Rational.Properties as ℚP
 open ℚ using (ℚ)
 
 open import Data.List.Properties using (∷-injective; map-++; length-map)
@@ -169,25 +170,21 @@ module _ (baseLiv : BL.Liveness) where
             length-eq = trans (sym (length-map getBaseBlock suff'))
                               (cong length msuff≡)
 
-            step₁ : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LB.slotOf b)
-                  ℚ.≤ ℕ→ℚ (length suff')
-            step₁ = subst (λ y → τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ y)
-                               ℚ.≤ ℕ→ℚ (length suff'))
-                          slotOf-eq ext-bound
-
-            step₂ : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
-                                ∸ LB.slotOf b)
-                  ℚ.≤ ℕ→ℚ (length suff')
-            step₂ = subst (λ x → τ ℚ.* ℕ→ℚ (x ∸ LB.slotOf b)
-                               ℚ.≤ ℕ→ℚ (length suff'))
-                          slot-eq step₁
-
             result : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
                                  ∸ LB.slotOf b)
                    ℚ.≤ ℕ→ℚ (length suff)
-            result = subst (λ y → τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
-                                               ∸ LB.slotOf b) ℚ.≤ ℕ→ℚ y)
-                           length-eq step₂
+            result = let open ℚP.≤-Reasoning in
+              begin
+                τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ LB.slotOf b)
+              ≡⟨ cong (λ x → τ ℚ.* ℕ→ℚ (x ∸ LB.slotOf b)) (sym slot-eq) ⟩
+                τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LB.slotOf b)
+              ≡⟨ cong (λ y → τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ y)) (sym slotOf-eq) ⟩
+                τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b')
+              ≤⟨ ext-bound ⟩
+                ℕ→ℚ (length suff')
+              ≡⟨ cong ℕ→ℚ length-eq ⟩
+                ℕ→ℚ (length suff)
+              ∎
 
       hcgState-base⇒ext : ∀ τ
         → LB.hcgState τ (transEnv E) (transState E s)

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -1,0 +1,303 @@
+{-# OPTIONS --safe #-}
+
+open import Leios.Prelude hiding (id; _⊗_; _∘_)
+open import Blockchain.Safety
+open import Blockchain.Liveness
+open import Leios.ChannelCat
+
+open import CategoricalCrypto hiding (id)
+import CategoricalCrypto as CC
+
+import Data.Integer as ℤ
+import Data.Rational as ℚ
+open ℚ using (ℚ)
+
+open import Data.List.Properties using (∷-injective; map-++; length-map; filter-accept; filter-reject)
+import Data.List.Relation.Unary.Any.Properties as AnyP
+import Data.List as L
+
+-- | Generic liveness transfer.
+--
+-- Given the same ingredients as `Blockchain.Safety.Transfer` (an extended
+-- blockchain spec `ext`, a chain-projection `getBaseBlock` into a base
+-- blockchain spec, and an honest upper layer `ext-spec`) and a `Liveness`
+-- record for the derived base spec, we derive a `Liveness` record for the
+-- ext spec by pulling back `producer` and `slotOf` along `getBaseBlock`,
+-- and show that HCG and ∃CQ transfer from base to ext.
+module Blockchain.Liveness.Transfer
+  {BlockExt BlockBase   : Type}
+  (getBaseBlock         : BlockExt → BlockBase)
+  (getBaseBlock-inj     : Injective _≡_ _≡_ getBaseBlock)
+  (ext                  : Safety BlockExt)
+  (cc                   : ChannelCat)
+  (base-IO base-Adv     : Channel)
+  (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
+  (base-IsBlockchain    : IsBlockchain BlockBase base-spec)
+  (ext-Adv≡base-Adv     : Safety.Adv ext ≡ base-Adv)
+  (ext-spec             : Machine base-IO (Safety.IO ext ⊗₀ I))
+  where
+
+import Blockchain.Safety.Transfer as ST
+module Tr = ST
+  getBaseBlock getBaseBlock-inj ext cc
+  base-IO base-Adv base-spec base-IsBlockchain
+  ext-Adv≡base-Adv ext-spec
+
+open Tr using (extPart; base-all-nodes)
+
+module Ext  = Tr.Ext
+module Base = Tr.Base
+
+private
+  ℕ→ℚ : ℕ → ℚ
+  ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
+
+-- A splitting of `map f l` lifts to a splitting of `l`.
+private
+  map-split : ∀ {A B} {f : A → B} (l : List A) (pref : List B) (b : B) (suff : List B)
+    → map f l ≡ pref ++ b ∷ suff
+    → Σ[ pref' ∈ List A ] Σ[ b' ∈ A ] Σ[ suff' ∈ List A ]
+         (l ≡ pref' ++ b' ∷ suff')
+       × (map f pref' ≡ pref)
+       × (f b' ≡ b)
+       × (map f suff' ≡ suff)
+  map-split (x ∷ xs) []         b suff eq =
+    case ∷-injective eq of λ where
+      (fx≡b , mxs≡suff) → [] , x , xs , refl , refl , fx≡b , mxs≡suff
+  map-split (x ∷ xs) (p ∷ pref) b suff eq =
+    case ∷-injective eq of λ where
+      (fx≡p , rest-eq) →
+        case map-split xs pref b suff rest-eq of λ where
+          (pref' , b' , suff' , xs≡ , mpref≡ , fb'≡ , msuff≡) →
+            (x ∷ pref') , b' , suff'
+              , cong (x ∷_) xs≡
+              , cong₂ _∷_ fx≡p mpref≡
+              , fb'≡
+              , msuff≡
+
+module BL = Blockchain.Liveness BlockBase Tr.base
+module EL = Blockchain.Liveness BlockExt   ext
+
+-- Given a Liveness for the derived base spec, we derive a Liveness for the
+-- ext spec by pulling back `producer` and `slotOf` along `getBaseBlock`.
+module _ (baseLiv : BL.Liveness) where
+
+  private
+    module LB = BL.Liveness baseLiv
+
+  extLiv : EL.Liveness
+  extLiv = record
+    { producer = λ b → LB.producer (getBaseBlock b)
+    ; slotOf   = λ b → LB.slotOf   (getBaseBlock b)
+    }
+
+  private
+    module LE = EL.Liveness extLiv
+
+  module Main (single-protocol-≡ : ∀ p
+                                 → idᴷ ∘ᴷ Ext.all-nodes p
+                                 ≡ extPart p ∘ᴷ base-all-nodes p) where
+
+    module TrM = Tr.Main single-protocol-≡
+    open TrM using (transEnv; transState; transTrace; ChainLemma-ty)
+
+    -- Slot lemma: the base-side slot query agrees with the ext-side slot query.
+    SlotLemma-ty : ∀ {A : Channel} → Ext.Environment A → Type
+    SlotLemma-ty {A} E = ∀ {p : Fin Ext.n} {s} (p-honest : p ∈ Ext.honest-nodes)
+      → Base.getSlot (transEnv E) (transState E s) p-honest
+      ≡ Ext.getSlot E s p-honest
+
+    -- `recent` commutes with `map getBaseBlock`. The predicate
+    -- `λ b → slotOf b + T ≥ s` is decidable on ℕ and the decidability
+    -- instance used on the ext and base sides agrees up to `getBaseBlock`,
+    -- since `LE.slotOf` is defined as `LB.slotOf ∘ getBaseBlock`.
+    recent-map : ∀ T s (l : List BlockExt)
+      → LB.recent T s (map getBaseBlock l) ≡ map getBaseBlock (LE.recent T s l)
+    recent-map T s [] = refl
+    recent-map T s (x ∷ xs)
+      with ¿ LB.slotOf (getBaseBlock x) + T ≥ s ¿
+    ... | yes p =
+      let lhs-eq : LB.recent T s (getBaseBlock x ∷ map getBaseBlock xs)
+                 ≡ getBaseBlock x ∷ LB.recent T s (map getBaseBlock xs)
+          lhs-eq = filter-accept ¿ _ ¿¹ p
+          rhs-eq : LE.recent T s (x ∷ xs) ≡ x ∷ LE.recent T s xs
+          rhs-eq = filter-accept ¿ _ ¿¹ p
+      in trans lhs-eq
+               (trans (cong (getBaseBlock x ∷_) (recent-map T s xs))
+                      (cong (map getBaseBlock) (sym rhs-eq)))
+    ... | no ¬p =
+      let lhs-eq : LB.recent T s (getBaseBlock x ∷ map getBaseBlock xs)
+                 ≡ LB.recent T s (map getBaseBlock xs)
+          lhs-eq = filter-reject ¿ _ ¿¹ ¬p
+          rhs-eq : LE.recent T s (x ∷ xs) ≡ LE.recent T s xs
+          rhs-eq = filter-reject ¿ _ ¿¹ ¬p
+      in trans lhs-eq (trans (recent-map T s xs) (cong (map getBaseBlock) (sym rhs-eq)))
+
+    module _ {A : Channel} (E : Ext.Environment A)
+             (CL : ChainLemma-ty E) (SL : SlotLemma-ty E)
+             (s : Machine.State (Ext.protocol E)) where
+
+      -- HCG -----------------------------------------------------------------
+
+      hcgState-ext⇒base : ∀ τ
+        → LE.hcgState τ E s
+        → LB.hcgState τ (transEnv E) (transState E s)
+      hcgState-ext⇒base τ ext-hcg-s {p} hp {pref} {suff} {b} base-eq honest-b =
+        let mapped-eq : map getBaseBlock (Ext.getChain E s hp) ≡ pref ++ b ∷ suff
+            mapped-eq = trans (sym (CL hp)) base-eq
+        in case map-split (Ext.getChain E s hp) pref b suff mapped-eq of λ where
+          (pref' , b' , suff' , ext-eq , _ , fb'≡ , msuff≡) →
+            let honest-b' : LE.isHonestBlock b'
+                honest-b' = subst (λ x → LB.producer x ∈ Ext.honest-nodes)
+                              (sym fb'≡) honest-b
+
+                ext-bound : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b')
+                          ℚ.≤ ℕ→ℚ (length suff')
+                ext-bound = ext-hcg-s hp ext-eq honest-b'
+
+                slot-eq : Ext.getSlot E s hp
+                        ≡ Base.getSlot (transEnv E) (transState E s) hp
+                slot-eq = sym (SL hp)
+
+                slotOf-eq : LE.slotOf b' ≡ LB.slotOf b
+                slotOf-eq = cong LB.slotOf fb'≡
+
+                length-eq : length suff' ≡ length suff
+                length-eq = trans (sym (length-map getBaseBlock suff'))
+                                  (cong length msuff≡)
+
+                step₁ : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LB.slotOf b)
+                      ℚ.≤ ℕ→ℚ (length suff')
+                step₁ = subst (λ y → τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ y)
+                                   ℚ.≤ ℕ→ℚ (length suff'))
+                              slotOf-eq ext-bound
+
+                step₂ : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                                    ∸ LB.slotOf b)
+                      ℚ.≤ ℕ→ℚ (length suff')
+                step₂ = subst (λ x → τ ℚ.* ℕ→ℚ (x ∸ LB.slotOf b)
+                                   ℚ.≤ ℕ→ℚ (length suff'))
+                              slot-eq step₁
+            in subst (λ y → τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                                        ∸ LB.slotOf b) ℚ.≤ ℕ→ℚ y)
+                     length-eq step₂
+
+      hcgState-base⇒ext : ∀ τ
+        → LB.hcgState τ (transEnv E) (transState E s)
+        → LE.hcgState τ E s
+      hcgState-base⇒ext τ base-hcg-s {p} hp {pref} {suff} {b} ext-eq honest-b =
+        let base-eq : Base.getChain (transEnv E) (transState E s) hp
+                    ≡ map getBaseBlock pref ++ getBaseBlock b ∷ map getBaseBlock suff
+            base-eq = trans (CL hp)
+                            (trans (cong (map getBaseBlock) ext-eq)
+                                   (map-++ getBaseBlock pref (b ∷ suff)))
+
+            bound : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                                ∸ LB.slotOf (getBaseBlock b))
+                  ℚ.≤ ℕ→ℚ (length (map getBaseBlock suff))
+            bound = base-hcg-s hp base-eq honest-b
+
+            slot-eq : Base.getSlot (transEnv E) (transState E s) hp
+                    ≡ Ext.getSlot E s hp
+            slot-eq = SL hp
+
+            length-eq : length (map getBaseBlock suff) ≡ length suff
+            length-eq = length-map getBaseBlock suff
+        in subst₂ (λ x y → τ ℚ.* ℕ→ℚ (x ∸ LE.slotOf b) ℚ.≤ ℕ→ℚ y)
+                  slot-eq length-eq bound
+
+      -- ∃CQ -----------------------------------------------------------------
+
+      ∃cqState-ext⇒base : ∀ T
+        → LE.∃cqState T E s
+        → LB.∃cqState T (transEnv E) (transState E s)
+      ∃cqState-ext⇒base T ext-∃cq-s {p} hp =
+        let ext-any : Any.Any LE.isHonestBlock
+                        (LE.recent T (Ext.getSlot E s hp) (Ext.getChain E s hp))
+            ext-any = ext-∃cq-s hp
+
+            mapped-any : Any.Any LE.isHonestBlock
+                          (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
+                                       (Ext.getChain E s hp))
+            mapped-any = subst (λ x → Any.Any LE.isHonestBlock
+                                         (LE.recent T x (Ext.getChain E s hp)))
+                               (sym (SL hp)) ext-any
+
+            -- Push `map getBaseBlock` inside `recent` via `recent-map`.
+            any-on-map : Any.Any LB.isHonestBlock
+                          (map getBaseBlock
+                            (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
+                                        (Ext.getChain E s hp)))
+            any-on-map = AnyP.map⁺ mapped-any
+
+            any-base-recent : Any.Any LB.isHonestBlock
+                                (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp)
+                                             (map getBaseBlock (Ext.getChain E s hp)))
+            any-base-recent =
+              subst (Any.Any LB.isHonestBlock)
+                    (sym (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
+                                     (Ext.getChain E s hp)))
+                    any-on-map
+
+        in subst (λ cs → Any.Any LB.isHonestBlock
+                           (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp) cs))
+                 (sym (CL hp))
+                 any-base-recent
+
+      ∃cqState-base⇒ext : ∀ T
+        → LB.∃cqState T (transEnv E) (transState E s)
+        → LE.∃cqState T E s
+      ∃cqState-base⇒ext T base-∃cq-s {p} hp =
+        let base-any : Any.Any LB.isHonestBlock
+                        (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp)
+                                     (Base.getChain (transEnv E) (transState E s) hp))
+            base-any = base-∃cq-s hp
+
+            -- Rewrite base chain → map getBaseBlock of ext chain.
+            step₁ : Any.Any LB.isHonestBlock
+                     (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp)
+                                  (map getBaseBlock (Ext.getChain E s hp)))
+            step₁ = subst (λ cs → Any.Any LB.isHonestBlock
+                                    (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp) cs))
+                          (CL hp) base-any
+
+            -- Pull `map getBaseBlock` out of `recent`.
+            step₂ : Any.Any LB.isHonestBlock
+                     (map getBaseBlock
+                       (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
+                                   (Ext.getChain E s hp)))
+            step₂ = subst (Any.Any LB.isHonestBlock)
+                          (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
+                                       (Ext.getChain E s hp))
+                          step₁
+
+            -- Any (P ∘ f) on original list.
+            step₃ : Any.Any LE.isHonestBlock
+                     (LE.recent T (Base.getSlot (transEnv E) (transState E s) hp)
+                                 (Ext.getChain E s hp))
+            step₃ = AnyP.map⁻ step₂
+        in subst (λ x → Any.Any LE.isHonestBlock
+                           (LE.recent T x (Ext.getChain E s hp)))
+                 (SL hp) step₃
+
+    -- Transfer the hcg and ∃cq invariants.
+
+    hcg-transfer : ∀ τ
+      → (∀ {A} (E : Ext.Environment A) → ChainLemma-ty E)
+      → (∀ {A} (E : Ext.Environment A) → SlotLemma-ty E)
+      → LB.hcg τ → LE.hcg τ
+    hcg-transfer τ CL SL base-hcg E init final trace hcg-init =
+      hcgState-base⇒ext E (CL E) (SL E) final τ
+        (base-hcg (transEnv E) (transState E init) (transState E final)
+                  (transTrace E trace)
+                  (hcgState-ext⇒base E (CL E) (SL E) init τ hcg-init))
+
+    ∃cq-transfer : ∀ T
+      → (∀ {A} (E : Ext.Environment A) → ChainLemma-ty E)
+      → (∀ {A} (E : Ext.Environment A) → SlotLemma-ty E)
+      → LB.∃cq T → LE.∃cq T
+    ∃cq-transfer T CL SL base-∃cq E init final trace ∃cq-init =
+      ∃cqState-base⇒ext E (CL E) (SL E) final T
+        (base-∃cq (transEnv E) (transState E init) (transState E final)
+                  (transTrace E trace)
+                  (∃cqState-ext⇒base E (CL E) (SL E) init T ∃cq-init))

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -19,28 +19,29 @@ open import Relation.Unary using (Decidable)
 
 -- | Generic liveness transfer.
 --
--- Given the same ingredients as `Blockchain.Safety.Transfer` plus an
--- `IsBlockchain-compatible` witness that the ext spec's `producer`/`slotOf`
--- factor through `getBaseBlock`, HCG and ∃CQ transfer from base to ext.
+-- Same shape as `Blockchain.Safety.Transfer`, plus two extra parameters
+-- (`producer-compat` and `slotOf-compat`) witnessing that the ext spec's
+-- `producer`/`slotOf` factor through `getBaseBlock`.  HCG and ∃CQ transfer
+-- from base to ext.
 module Blockchain.Liveness.Transfer
-  {BlockExt BlockBase   : Type}
-  (ext                  : Safety BlockExt)
-  (cc                   : ChannelCat)
-  (base-IO base-Adv     : Channel)
-  (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
-  (base-IsBlockchain    : IsBC.IsBlockchain (Fin (Safety.n ext)) BlockBase base-spec)
-  (compat               : IsBC.IsBlockchain-compatible (Fin (Safety.n ext)) base-IsBlockchain (Safety.spec-IsBlockchain ext))
-  (ext-Adv≡base-Adv     : Safety.Adv ext ≡ base-Adv)
-  (ext-spec             : Machine base-IO (Safety.IO ext ⊗₀ I))
+  {BlockExt BlockBase : Type}
+  (ext                : Safety BlockExt)
+  (cc                 : ChannelCat)
+  (extension          : IsExtension {BlockBase} (Safety.spec ext))
+  (producer-compat    : ∀ b → Safety.producer ext b
+                            ≡ IsBC.IsBlockchain.producer
+                                (IsExtension.base-IsBlockchain extension)
+                                (IsExtension.getBaseBlock extension b))
+  (slotOf-compat      : ∀ b → Safety.slotOf ext b
+                            ≡ IsBC.IsBlockchain.slotOf
+                                (IsExtension.base-IsBlockchain extension)
+                                (IsExtension.getBaseBlock extension b))
   where
 
-open IsBC.IsBlockchain-compatible compat
+open IsExtension extension
 
 import Blockchain.Safety.Transfer as ST
-module Tr = ST
-  getBaseBlock getBaseBlock-inj ext cc
-  base-IO base-Adv base-spec base-IsBlockchain
-  ext-Adv≡base-Adv ext-spec
+module Tr = ST ext cc extension
 
 open Tr using (extPart; base-all-nodes)
 

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -24,14 +24,14 @@ open import Relation.Unary using (Decidable)
 -- from base to ext.
 module Blockchain.Liveness.Transfer
   {BlockExt BlockBase : Type}
-  (ext                : Safety BlockExt)
-  (let module Ext = Safety ext)
+  (ext                : Deployment BlockExt)
+  (let module Ext = Deployment ext)
   (base-spec          : Spec BlockBase Ext.n Ext.Network)
   (cc                 : ChannelCat)
-  (extension          : IsExtension base-spec (Safety.spec ext))
-  (producer-compat    : ∀ b → Safety.producer ext b
+  (extension          : IsExtension base-spec Ext.spec)
+  (producer-compat    : ∀ b → Deployment.producer ext b
                             ≡ Spec.producer base-spec (IsExtension.getBaseBlock extension b))
-  (slotOf-compat      : ∀ b → Safety.slotOf ext b
+  (slotOf-compat      : ∀ b → Deployment.slotOf ext b
                             ≡ Spec.slotOf base-spec (IsExtension.getBaseBlock extension b))
   where
 

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -2,7 +2,6 @@
 
 open import Leios.Prelude hiding (id; _⊗_; _∘_)
 open import Blockchain.Safety
-import Blockchain.IsBlockchain as IsBC
 import Blockchain.Liveness
 open import Leios.ChannelCat
 

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -204,9 +204,18 @@ module Main (single-protocol-≡ : ∀ p
 
           result : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ Ext.slotOf b)
                  ℚ.≤ ℕ→ℚ (length suff)
-          result = subst₂ (λ x y → τ ℚ.* ℕ→ℚ (x ∸ Ext.slotOf b) ℚ.≤ ℕ→ℚ y) slot-eq length-eq
-                 $ subst (λ z → τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ z)
-                                ℚ.≤ ℕ→ℚ (length (map getBaseBlock suff))) slotOf-eq bound
+          result = let open ℚP.≤-Reasoning in
+            begin
+              τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ Ext.slotOf b)
+            ≡⟨ cong (λ x → τ ℚ.* ℕ→ℚ (x ∸ Ext.slotOf b)) (sym slot-eq) ⟩
+              τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ Ext.slotOf b)
+            ≡⟨ cong (λ y → τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ y)) (sym slotOf-eq) ⟩
+              τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ Base.slotOf (getBaseBlock b))
+            ≤⟨ bound ⟩
+              ℕ→ℚ (length (map getBaseBlock suff))
+            ≡⟨ cong ℕ→ℚ length-eq ⟩
+              ℕ→ℚ (length suff)
+            ∎
 
     -- ∃CQ -----------------------------------------------------------------
 

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -45,8 +45,6 @@ open Tr using (extPart; base-all-nodes)
 module Base = Tr.Base
 
 private
-  -- Generic lemma: filtering after mapping equals mapping after filtering
-  -- with the pulled-back predicate.
   filter-map : ∀ {A B : Type} {P : B → Type} (P? : Decidable P) (f : A → B)
                (xs : List A)
              → L.filter P? (L.map f xs) ≡ L.map f (L.filter (λ x → P? (f x)) xs)
@@ -55,8 +53,6 @@ private
   ... | yes _ = cong (f x ∷_) (filter-map P? f xs)
   ... | no  _ = filter-map P? f xs
 
--- A splitting of `map f l` lifts to a splitting of `l`.
-private
   map-split : ∀ {A B : Type} {f : A → B} (l : List A) (pref : List B) (b : B) (suff : List B)
     → map f l ≡ pref ++ b ∷ suff
     → Σ[ pref' ∈ List A ] Σ[ b' ∈ A ] Σ[ suff' ∈ List A ]
@@ -87,14 +83,11 @@ module Main where
   module TrM = Tr.Main
   open TrM using (transEnv; transState; transTrace; ChainLemma-ty)
 
-  -- Slot lemma: the base-side slot query agrees with the ext-side slot query.
   SlotLemma-ty : ∀ {A : Channel} → Ext.Environment A → Type
   SlotLemma-ty {A} E = ∀ {p : Fin Ext.n} {s} (p-honest : p ∈ Ext.honest-nodes)
     → Base.getSlot (transEnv E) (transState E s) p-honest
     ≡ Ext.getSlot E s p-honest
 
-  -- `recent` commutes with `map getBaseBlock`.  Follows from the generic
-  -- `filter-map` lemma together with `slotOf-compat`.
   recent-map : ∀ T s (l : List BlockExt)
     → BL.recent T s (map getBaseBlock l) ≡ map getBaseBlock (EL.recent T s l)
   recent-map T s l =

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -2,6 +2,7 @@
 
 open import Leios.Prelude hiding (id; _⊗_; _∘_)
 open import Blockchain.Safety
+import Blockchain.IsBlockchain as IsBC
 open import Blockchain.Liveness
 open import Leios.ChannelCat
 
@@ -13,7 +14,7 @@ import Data.Rational as ℚ
 import Data.Rational.Properties as ℚP
 open ℚ using (ℚ)
 
-open import Data.List.Properties using (∷-injective; map-++; length-map)
+open import Data.List.Properties using (∷-injective; map-++; length-map; filter-≐)
 import Data.List.Relation.Unary.Any.Properties as AnyP
 import Data.List as L
 open import Relation.Unary using (Decidable)
@@ -22,10 +23,9 @@ open import Relation.Unary using (Decidable)
 --
 -- Given the same ingredients as `Blockchain.Safety.Transfer` (an extended
 -- blockchain spec `ext`, a chain-projection `getBaseBlock` into a base
--- blockchain spec, and an honest upper layer `ext-spec`) and a `Liveness`
--- record for the derived base spec, we derive a `Liveness` record for the
--- ext spec by pulling back `producer` and `slotOf` along `getBaseBlock`,
--- and show that HCG and ∃CQ transfer from base to ext.
+-- blockchain spec, and an honest upper layer `ext-spec`), plus compatibility
+-- witnesses that `producer` and `slotOf` (now fields of `IsBlockchain`) agree
+-- across the projection, HCG and ∃CQ transfer from base to ext.
 module Blockchain.Liveness.Transfer
   {BlockExt BlockBase   : Type}
   (getBaseBlock         : BlockExt → BlockBase)
@@ -34,9 +34,18 @@ module Blockchain.Liveness.Transfer
   (cc                   : ChannelCat)
   (base-IO base-Adv     : Channel)
   (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
-  (base-IsBlockchain    : IsBlockchain BlockBase base-spec)
+  (base-IsBlockchain    : IsBC.IsBlockchain BlockBase (Fin (Safety.n ext)) base-spec)
   (ext-Adv≡base-Adv     : Safety.Adv ext ≡ base-Adv)
   (ext-spec             : Machine base-IO (Safety.IO ext ⊗₀ I))
+  -- Compatibility of the block-level metadata across the projection.  These
+  -- hold by construction whenever the base `producer`/`slotOf` are obtained by
+  -- projecting the ext ones through `getBaseBlock`.
+  (producer-compat      : let open Safety ext renaming (producer to ext-producer) in
+                          let open IsBC.IsBlockchain base-IsBlockchain renaming (producer to base-producer) in
+                            ∀ b → ext-producer b ≡ base-producer (getBaseBlock b))
+  (slotOf-compat        : let open Safety ext renaming (slotOf to ext-slotOf) in
+                          let open IsBC.IsBlockchain base-IsBlockchain renaming (slotOf to base-slotOf) in
+                            ∀ b → ext-slotOf b ≡ base-slotOf (getBaseBlock b))
   where
 
 import Blockchain.Safety.Transfer as ST
@@ -55,8 +64,7 @@ private
   ℕ→ℚ n = (ℤ.+ n) ℚ./ 1
 
   -- Generic lemma: filtering after mapping equals mapping after filtering
-  -- with the pulled-back predicate. Proof is the standard induction on
-  -- `xs` with case analysis on `P? (f x)`.
+  -- with the pulled-back predicate.
   filter-map : ∀ {A B : Type} {P : B → Type} (P? : Decidable P) (f : A → B)
                (xs : List A)
              → L.filter P? (L.map f xs) ≡ L.map f (L.filter (λ x → P? (f x)) xs)
@@ -91,199 +99,205 @@ private
 module BL = Blockchain.Liveness BlockBase Tr.base
 module EL = Blockchain.Liveness BlockExt   ext
 
--- Given a Liveness for the derived base spec, we derive a Liveness for the
--- ext spec by pulling back `producer` and `slotOf` along `getBaseBlock`.
-module _ (baseLiv : BL.Liveness) where
+module Main (single-protocol-≡ : ∀ p
+                               → idᴷ ∘ᴷ Ext.all-nodes p
+                               ≡ extPart p ∘ᴷ base-all-nodes p) where
 
-  private
-    module LB = BL.Liveness baseLiv
+  module TrM = Tr.Main single-protocol-≡
+  open TrM using (transEnv; transState; transTrace; ChainLemma-ty)
 
-  extLiv : EL.Liveness
-  extLiv = record
-    { producer = λ b → LB.producer (getBaseBlock b)
-    ; slotOf   = λ b → LB.slotOf   (getBaseBlock b)
-    }
+  -- Slot lemma: the base-side slot query agrees with the ext-side slot query.
+  SlotLemma-ty : ∀ {A : Channel} → Ext.Environment A → Type
+  SlotLemma-ty {A} E = ∀ {p : Fin Ext.n} {s} (p-honest : p ∈ Ext.honest-nodes)
+    → Base.getSlot (transEnv E) (transState E s) p-honest
+    ≡ Ext.getSlot E s p-honest
 
-  private
-    module LE = EL.Liveness extLiv
+  -- `recent` commutes with `map getBaseBlock`.  Follows from the generic
+  -- `filter-map` lemma together with `slotOf-compat`.
+  recent-map : ∀ T s (l : List BlockExt)
+    → BL.recent T s (map getBaseBlock l) ≡ map getBaseBlock (EL.recent T s l)
+  recent-map T s l =
+    trans (filter-map ¿ _ ¿¹ getBaseBlock l)
+          (cong (map getBaseBlock)
+            (filter-≐ (λ x → ¿ Base.slotOf (getBaseBlock x) + T ≥ s ¿)
+                      ¿ _ ¿¹
+                      ( (λ {x} p → subst (λ y → y + T ≥ s) (sym (slotOf-compat x)) p)
+                      , (λ {x} q → subst (λ y → y + T ≥ s) (slotOf-compat x) q))
+                      l))
 
-  module Main (single-protocol-≡ : ∀ p
-                                 → idᴷ ∘ᴷ Ext.all-nodes p
-                                 ≡ extPart p ∘ᴷ base-all-nodes p) where
+  module _ {A : Channel} (E : Ext.Environment A)
+           (CL : ChainLemma-ty E) (SL : SlotLemma-ty E)
+           (s : Machine.State (Ext.protocol E)) where
 
-    module TrM = Tr.Main single-protocol-≡
-    open TrM using (transEnv; transState; transTrace; ChainLemma-ty)
+    -- HCG -----------------------------------------------------------------
 
-    -- Slot lemma: the base-side slot query agrees with the ext-side slot query.
-    SlotLemma-ty : ∀ {A : Channel} → Ext.Environment A → Type
-    SlotLemma-ty {A} E = ∀ {p : Fin Ext.n} {s} (p-honest : p ∈ Ext.honest-nodes)
-      → Base.getSlot (transEnv E) (transState E s) p-honest
-      ≡ Ext.getSlot E s p-honest
+    hcgState-ext⇒base : ∀ τ
+      → EL.hcgState τ E s
+      → BL.hcgState τ (transEnv E) (transState E s)
+    hcgState-ext⇒base τ ext-hcg-s {p} hp {pref} {suff} {b} base-eq honest-b =
+      case map-split (Ext.getChain E s hp) pref b suff
+             (trans (sym (CL hp)) base-eq) of λ where
+        (pref' , b' , suff' , ext-eq , _ , fb'≡ , msuff≡) →
+          H.result pref' b' suff' ext-eq fb'≡ msuff≡
+      where
+        module H (pref' : List BlockExt) (b' : BlockExt) (suff' : List BlockExt)
+                 (ext-eq  : Ext.getChain E s hp ≡ pref' ++ b' ∷ suff')
+                 (fb'≡    : getBaseBlock b' ≡ b)
+                 (msuff≡  : map getBaseBlock suff' ≡ suff) where
 
-    -- `recent` commutes with `map getBaseBlock`. Follows from the generic
-    -- `filter-map` lemma together with the fact that `LE.slotOf = LB.slotOf ∘ getBaseBlock`
-    -- (which holds by definition of `extLiv`).
-    recent-map : ∀ T s (l : List BlockExt)
-      → LB.recent T s (map getBaseBlock l) ≡ map getBaseBlock (LE.recent T s l)
-    recent-map T s l = filter-map ¿ _ ¿¹ getBaseBlock l
+          honest-b' : EL.isHonestBlock b'
+          honest-b' = subst (λ x → x ∈ Ext.honest-nodes)
+                            (trans (producer-compat b') (cong Base.producer fb'≡) |> sym)
+                            honest-b
 
-    module _ {A : Channel} (E : Ext.Environment A)
-             (CL : ChainLemma-ty E) (SL : SlotLemma-ty E)
-             (s : Machine.State (Ext.protocol E)) where
+          ext-bound : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ Ext.slotOf b')
+                    ℚ.≤ ℕ→ℚ (length suff')
+          ext-bound = ext-hcg-s hp ext-eq honest-b'
 
-      -- HCG -----------------------------------------------------------------
+          slot-eq : Ext.getSlot E s hp
+                  ≡ Base.getSlot (transEnv E) (transState E s) hp
+          slot-eq = sym (SL hp)
 
-      hcgState-ext⇒base : ∀ τ
-        → LE.hcgState τ E s
-        → LB.hcgState τ (transEnv E) (transState E s)
-      hcgState-ext⇒base τ ext-hcg-s {p} hp {pref} {suff} {b} base-eq honest-b =
-        case map-split (Ext.getChain E s hp) pref b suff
-               (trans (sym (CL hp)) base-eq) of λ where
-          (pref' , b' , suff' , ext-eq , _ , fb'≡ , msuff≡) →
-            H.result pref' b' suff' ext-eq fb'≡ msuff≡
-        where
-          -- All the per-branch reasoning lives in a helper module so each
-          -- step's type signature is elaborated exactly once with the
-          -- destructured arguments as module parameters, instead of being
-          -- re-elaborated inside a nested `let`.
-          module H (pref' : List BlockExt) (b' : BlockExt) (suff' : List BlockExt)
-                   (ext-eq  : Ext.getChain E s hp ≡ pref' ++ b' ∷ suff')
-                   (fb'≡    : getBaseBlock b' ≡ b)
-                   (msuff≡  : map getBaseBlock suff' ≡ suff) where
+          slotOf-eq : Ext.slotOf b' ≡ Base.slotOf b
+          slotOf-eq = trans (slotOf-compat b') (cong Base.slotOf fb'≡)
 
-            honest-b' : LE.isHonestBlock b'
-            honest-b' = subst (λ x → LB.producer x ∈ Ext.honest-nodes)
-                              (sym fb'≡) honest-b
+          length-eq : length suff' ≡ length suff
+          length-eq = trans (sym (length-map getBaseBlock suff'))
+                            (cong length msuff≡)
 
-            ext-bound : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b')
-                      ℚ.≤ ℕ→ℚ (length suff')
-            ext-bound = ext-hcg-s hp ext-eq honest-b'
+          result : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                               ∸ Base.slotOf b)
+                 ℚ.≤ ℕ→ℚ (length suff)
+          result = let open ℚP.≤-Reasoning in
+            begin
+              τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ Base.slotOf b)
+            ≡⟨ cong (λ x → τ ℚ.* ℕ→ℚ (x ∸ Base.slotOf b)) (sym slot-eq) ⟩
+              τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ Base.slotOf b)
+            ≡⟨ cong (λ y → τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ y)) (sym slotOf-eq) ⟩
+              τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ Ext.slotOf b')
+            ≤⟨ ext-bound ⟩
+              ℕ→ℚ (length suff')
+            ≡⟨ cong ℕ→ℚ length-eq ⟩
+              ℕ→ℚ (length suff)
+            ∎
 
-            slot-eq : Ext.getSlot E s hp
-                    ≡ Base.getSlot (transEnv E) (transState E s) hp
-            slot-eq = sym (SL hp)
+    hcgState-base⇒ext : ∀ τ
+      → BL.hcgState τ (transEnv E) (transState E s)
+      → EL.hcgState τ E s
+    hcgState-base⇒ext τ base-hcg-s {p} hp {pref} {suff} {b} ext-eq honest-b =
+      H.result
+      where
+        module H where
 
-            slotOf-eq : LE.slotOf b' ≡ LB.slotOf b
-            slotOf-eq = cong LB.slotOf fb'≡
+          honest-base-b : Base.producer (getBaseBlock b) ∈ Ext.honest-nodes
+          honest-base-b = subst (λ x → x ∈ Ext.honest-nodes)
+                                 (producer-compat b)
+                                 honest-b
 
-            length-eq : length suff' ≡ length suff
-            length-eq = trans (sym (length-map getBaseBlock suff'))
-                              (cong length msuff≡)
+          base-eq : Base.getChain (transEnv E) (transState E s) hp
+                  ≡ map getBaseBlock pref ++ getBaseBlock b ∷ map getBaseBlock suff
+          base-eq = trans (CL hp)
+                          (trans (cong (map getBaseBlock) ext-eq)
+                                 (map-++ getBaseBlock pref (b ∷ suff)))
 
-            result : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
-                                 ∸ LB.slotOf b)
-                   ℚ.≤ ℕ→ℚ (length suff)
-            result = let open ℚP.≤-Reasoning in
-              begin
-                τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ LB.slotOf b)
-              ≡⟨ cong (λ x → τ ℚ.* ℕ→ℚ (x ∸ LB.slotOf b)) (sym slot-eq) ⟩
-                τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LB.slotOf b)
-              ≡⟨ cong (λ y → τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ y)) (sym slotOf-eq) ⟩
-                τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b')
-              ≤⟨ ext-bound ⟩
-                ℕ→ℚ (length suff')
-              ≡⟨ cong ℕ→ℚ length-eq ⟩
-                ℕ→ℚ (length suff)
-              ∎
+          bound : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
+                              ∸ Base.slotOf (getBaseBlock b))
+                ℚ.≤ ℕ→ℚ (length (map getBaseBlock suff))
+          bound = base-hcg-s hp base-eq honest-base-b
 
-      hcgState-base⇒ext : ∀ τ
-        → LB.hcgState τ (transEnv E) (transState E s)
-        → LE.hcgState τ E s
-      hcgState-base⇒ext τ base-hcg-s {p} hp {pref} {suff} {b} ext-eq honest-b =
-        H.result
-        where
-          module H where
+          slot-eq : Base.getSlot (transEnv E) (transState E s) hp
+                  ≡ Ext.getSlot E s hp
+          slot-eq = SL hp
 
-            base-eq : Base.getChain (transEnv E) (transState E s) hp
-                    ≡ map getBaseBlock pref ++ getBaseBlock b ∷ map getBaseBlock suff
-            base-eq = trans (CL hp)
-                            (trans (cong (map getBaseBlock) ext-eq)
-                                   (map-++ getBaseBlock pref (b ∷ suff)))
+          length-eq : length (map getBaseBlock suff) ≡ length suff
+          length-eq = length-map getBaseBlock suff
 
-            bound : τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp
-                                ∸ LB.slotOf (getBaseBlock b))
-                  ℚ.≤ ℕ→ℚ (length (map getBaseBlock suff))
-            bound = base-hcg-s hp base-eq honest-b
+          slotOf-eq : Base.slotOf (getBaseBlock b) ≡ Ext.slotOf b
+          slotOf-eq = sym (slotOf-compat b)
 
-            slot-eq : Base.getSlot (transEnv E) (transState E s) hp
-                    ≡ Ext.getSlot E s hp
-            slot-eq = SL hp
+          result : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ Ext.slotOf b)
+                 ℚ.≤ ℕ→ℚ (length suff)
+          result = subst₂ (λ x y → τ ℚ.* ℕ→ℚ (x ∸ Ext.slotOf b) ℚ.≤ ℕ→ℚ y) slot-eq length-eq
+                 $ subst (λ z → τ ℚ.* ℕ→ℚ (Base.getSlot (transEnv E) (transState E s) hp ∸ z)
+                                ℚ.≤ ℕ→ℚ (length (map getBaseBlock suff))) slotOf-eq bound
 
-            length-eq : length (map getBaseBlock suff) ≡ length suff
-            length-eq = length-map getBaseBlock suff
+    -- ∃CQ -----------------------------------------------------------------
 
-            result : τ ℚ.* ℕ→ℚ (Ext.getSlot E s hp ∸ LE.slotOf b)
-                   ℚ.≤ ℕ→ℚ (length suff)
-            result = subst₂ (λ x y → τ ℚ.* ℕ→ℚ (x ∸ LE.slotOf b) ℚ.≤ ℕ→ℚ y)
-                            slot-eq length-eq bound
+    ∃cqState-ext⇒base : ∀ T
+      → EL.∃cqState T E s
+      → BL.∃cqState T (transEnv E) (transState E s)
+    ∃cqState-ext⇒base T ext-∃cq-s {p} hp =
+      let ext-any = ext-∃cq-s hp
 
-      -- ∃CQ -----------------------------------------------------------------
+          mapped-any = subst (λ x → Any.Any EL.isHonestBlock
+                                       (EL.recent T x (Ext.getChain E s hp)))
+                             (sym (SL hp)) ext-any
 
-      ∃cqState-ext⇒base : ∀ T
-        → LE.∃cqState T E s
-        → LB.∃cqState T (transEnv E) (transState E s)
-      ∃cqState-ext⇒base T ext-∃cq-s {p} hp =
-        let ext-any = ext-∃cq-s hp
+          -- Transport honesty along `producer-compat`.
+          any-base-honest = Any.map
+            (λ {b} hb → subst (λ x → x ∈ Ext.honest-nodes) (producer-compat b) hb)
+            mapped-any
 
-            mapped-any = subst (λ x → Any.Any LE.isHonestBlock
-                                         (LE.recent T x (Ext.getChain E s hp)))
-                               (sym (SL hp)) ext-any
+          -- Push `map getBaseBlock` inside `recent` via `recent-map`.
+          any-on-map = AnyP.map⁺ any-base-honest
 
-            -- Push `map getBaseBlock` inside `recent` via `recent-map`.
-            any-on-map = AnyP.map⁺ mapped-any
+          any-base-recent =
+            subst (Any.Any BL.isHonestBlock)
+                  (sym (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
+                                   (Ext.getChain E s hp)))
+                  any-on-map
 
-            any-base-recent =
-              subst (Any.Any LB.isHonestBlock)
-                    (sym (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
-                                     (Ext.getChain E s hp)))
-                    any-on-map
+      in subst (λ cs → Any.Any BL.isHonestBlock
+                         (BL.recent T (Base.getSlot (transEnv E) (transState E s) hp) cs))
+               (sym (CL hp))
+               any-base-recent
 
-        in subst (λ cs → Any.Any LB.isHonestBlock
-                           (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp) cs))
-                 (sym (CL hp))
-                 any-base-recent
+    ∃cqState-base⇒ext : ∀ T
+      → BL.∃cqState T (transEnv E) (transState E s)
+      → EL.∃cqState T E s
+    ∃cqState-base⇒ext T base-∃cq-s {p} hp =
+      let base-any = base-∃cq-s hp
 
-      ∃cqState-base⇒ext : ∀ T
-        → LB.∃cqState T (transEnv E) (transState E s)
-        → LE.∃cqState T E s
-      ∃cqState-base⇒ext T base-∃cq-s {p} hp =
-        let base-any = base-∃cq-s hp
+          -- Rewrite base chain → map getBaseBlock of ext chain.
+          step₁ = subst (λ cs → Any.Any BL.isHonestBlock
+                                  (BL.recent T (Base.getSlot (transEnv E) (transState E s) hp) cs))
+                        (CL hp) base-any
 
-            -- Rewrite base chain → map getBaseBlock of ext chain.
-            step₁ = subst (λ cs → Any.Any LB.isHonestBlock
-                                    (LB.recent T (Base.getSlot (transEnv E) (transState E s) hp) cs))
-                          (CL hp) base-any
+          -- Pull `map getBaseBlock` out of `recent`.
+          step₂ = subst (Any.Any BL.isHonestBlock)
+                        (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
+                                     (Ext.getChain E s hp))
+                        step₁
 
-            -- Pull `map getBaseBlock` out of `recent`.
-            step₂ = subst (Any.Any LB.isHonestBlock)
-                          (recent-map T (Base.getSlot (transEnv E) (transState E s) hp)
-                                       (Ext.getChain E s hp))
-                          step₁
+          -- Any (P ∘ f) on original list.
+          step₃ = AnyP.map⁻ step₂
 
-            -- Any (P ∘ f) on original list.
-            step₃ = AnyP.map⁻ step₂
-        in subst (λ x → Any.Any LE.isHonestBlock
-                           (LE.recent T x (Ext.getChain E s hp)))
-                 (SL hp) step₃
+          -- Transport honesty back through `producer-compat`.
+          step₄ = Any.map
+            (λ {b} hb → subst (λ x → x ∈ Ext.honest-nodes) (sym (producer-compat b)) hb)
+            step₃
+      in subst (λ x → Any.Any EL.isHonestBlock
+                         (EL.recent T x (Ext.getChain E s hp)))
+               (SL hp) step₄
 
-    -- Transfer the hcg and ∃cq invariants.
+  -- Transfer the hcg and ∃cq invariants.
 
-    hcg-transfer : ∀ τ
-      → (∀ {A} (E : Ext.Environment A) → ChainLemma-ty E)
-      → (∀ {A} (E : Ext.Environment A) → SlotLemma-ty E)
-      → LB.hcg τ → LE.hcg τ
-    hcg-transfer τ CL SL base-hcg E init final trace hcg-init =
-      hcgState-base⇒ext E (CL E) (SL E) final τ
-        (base-hcg (transEnv E) (transState E init) (transState E final)
-                  (transTrace E trace)
-                  (hcgState-ext⇒base E (CL E) (SL E) init τ hcg-init))
+  hcg-transfer : ∀ τ
+    → (∀ {A} (E : Ext.Environment A) → ChainLemma-ty E)
+    → (∀ {A} (E : Ext.Environment A) → SlotLemma-ty E)
+    → BL.hcg τ → EL.hcg τ
+  hcg-transfer τ CL SL base-hcg E init final trace hcg-init =
+    hcgState-base⇒ext E (CL E) (SL E) final τ
+      (base-hcg (transEnv E) (transState E init) (transState E final)
+                (transTrace E trace)
+                (hcgState-ext⇒base E (CL E) (SL E) init τ hcg-init))
 
-    ∃cq-transfer : ∀ T
-      → (∀ {A} (E : Ext.Environment A) → ChainLemma-ty E)
-      → (∀ {A} (E : Ext.Environment A) → SlotLemma-ty E)
-      → LB.∃cq T → LE.∃cq T
-    ∃cq-transfer T CL SL base-∃cq E init final trace ∃cq-init =
-      ∃cqState-base⇒ext E (CL E) (SL E) final T
-        (base-∃cq (transEnv E) (transState E init) (transState E final)
-                  (transTrace E trace)
-                  (∃cqState-ext⇒base E (CL E) (SL E) init T ∃cq-init))
+  ∃cq-transfer : ∀ T
+    → (∀ {A} (E : Ext.Environment A) → ChainLemma-ty E)
+    → (∀ {A} (E : Ext.Environment A) → SlotLemma-ty E)
+    → BL.∃cq T → EL.∃cq T
+  ∃cq-transfer T CL SL base-∃cq E init final trace ∃cq-init =
+    ∃cqState-base⇒ext E (CL E) (SL E) final T
+      (base-∃cq (transEnv E) (transState E init) (transState E final)
+                (transTrace E trace)
+                (∃cqState-ext⇒base E (CL E) (SL E) init T ∃cq-init))

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -26,26 +26,23 @@ open import Relation.Unary using (Decidable)
 module Blockchain.Liveness.Transfer
   {BlockExt BlockBase : Type}
   (ext                : Safety BlockExt)
+  (let module Ext = Safety ext)
+  (base-spec          : Spec BlockBase Ext.n Ext.Network)
   (cc                 : ChannelCat)
-  (extension          : IsExtension {BlockBase} (Safety.spec ext))
+  (extension          : IsExtension base-spec (Safety.spec ext))
   (producer-compat    : ∀ b → Safety.producer ext b
-                            ≡ IsBC.IsBlockchain.producer
-                                (IsExtension.base-IsBlockchain extension)
-                                (IsExtension.getBaseBlock extension b))
+                            ≡ Spec.producer base-spec (IsExtension.getBaseBlock extension b))
   (slotOf-compat      : ∀ b → Safety.slotOf ext b
-                            ≡ IsBC.IsBlockchain.slotOf
-                                (IsExtension.base-IsBlockchain extension)
-                                (IsExtension.getBaseBlock extension b))
+                            ≡ Spec.slotOf base-spec (IsExtension.getBaseBlock extension b))
   where
 
 open IsExtension extension
 
 import Blockchain.Safety.Transfer as ST
-module Tr = ST ext cc extension
+module Tr = ST ext base-spec cc extension
 
 open Tr using (extPart; base-all-nodes)
 
-module Ext  = Tr.Ext
 module Base = Tr.Base
 
 private

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -28,25 +28,17 @@ open import Relation.Unary using (Decidable)
 -- across the projection, HCG and ∃CQ transfer from base to ext.
 module Blockchain.Liveness.Transfer
   {BlockExt BlockBase   : Type}
-  (getBaseBlock         : BlockExt → BlockBase)
-  (getBaseBlock-inj     : Injective _≡_ _≡_ getBaseBlock)
   (ext                  : Safety BlockExt)
   (cc                   : ChannelCat)
   (base-IO base-Adv     : Channel)
   (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
-  (base-IsBlockchain    : IsBC.IsBlockchain BlockBase (Fin (Safety.n ext)) base-spec)
+  (base-IsBlockchain    : IsBC.IsBlockchain (Fin (Safety.n ext)) BlockBase base-spec)
+  (compat               : IsBC.IsBlockchain-compatible (Fin (Safety.n ext)) base-IsBlockchain (Safety.spec-IsBlockchain ext))
   (ext-Adv≡base-Adv     : Safety.Adv ext ≡ base-Adv)
   (ext-spec             : Machine base-IO (Safety.IO ext ⊗₀ I))
-  -- Compatibility of the block-level metadata across the projection.  These
-  -- hold by construction whenever the base `producer`/`slotOf` are obtained by
-  -- projecting the ext ones through `getBaseBlock`.
-  (producer-compat      : let open Safety ext renaming (producer to ext-producer) in
-                          let open IsBC.IsBlockchain base-IsBlockchain renaming (producer to base-producer) in
-                            ∀ b → ext-producer b ≡ base-producer (getBaseBlock b))
-  (slotOf-compat        : let open Safety ext renaming (slotOf to ext-slotOf) in
-                          let open IsBC.IsBlockchain base-IsBlockchain renaming (slotOf to base-slotOf) in
-                            ∀ b → ext-slotOf b ≡ base-slotOf (getBaseBlock b))
   where
+
+open IsBC.IsBlockchain-compatible compat
 
 import Blockchain.Safety.Transfer as ST
 module Tr = ST

--- a/formal-spec/Blockchain/Liveness/Transfer.agda
+++ b/formal-spec/Blockchain/Liveness/Transfer.agda
@@ -83,11 +83,9 @@ module BL = Blockchain.Liveness BlockBase Tr.base
 module EL = Blockchain.Liveness BlockExt   ext
 open BL using (ℕ→ℚ)
 
-module Main (single-protocol-≡ : ∀ p
-                               → idᴷ ∘ᴷ Ext.all-nodes p
-                               ≡ extPart p ∘ᴷ base-all-nodes p) where
+module Main where
 
-  module TrM = Tr.Main single-protocol-≡
+  module TrM = Tr.Main
   open TrM using (transEnv; transState; transTrace; ChainLemma-ty)
 
   -- Slot lemma: the base-side slot query agrees with the ext-side slot query.

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -4,27 +4,18 @@ open import Leios.Prelude hiding (id; _⊗_)
 
 open import CategoricalCrypto hiding (id; _∘_)
 
+import Blockchain.IsBlockchain as IsBC
+
 module Blockchain.Safety (Block : Type) where
-
--- | Type of things we can query from a honest node
-data BlockChainInfo : Type where
-  Chain : BlockChainInfo
-  Slot  : BlockChainInfo
-
--- | Type for responses given a specific query
-bciQueryType : BlockChainInfo → Type
-bciQueryType Chain = List Block
-bciQueryType Slot  = ℕ
-
-record IsBlockchain {A B : Channel} (m : Machine A B) : Type₂ where
-  field 
-    isConstrained : IsConstrained m bciQueryType
-    isPure        : IsPure isConstrained 
 
 record Safety : Type₂ where
   field
     -- Number of involved nodes
     n                        : ℕ
+
+  open IsBC Block (Fin n) public
+
+  field
     -- Communication channels involved in the network
     IO Adv NAdv Network      : Channel
     -- Machine describing the behavior of the honest nodes
@@ -41,6 +32,8 @@ record Safety : Type₂ where
     honest-nodes-≡-spec      : ∀ {p} → p ∈ honest-nodes → all-nodes p ≡ᴹ honest-node-spec
     -- The network machine
     network                  : Machine I (n ⨂ⁿ Network ⊗₀ NAdv)
+
+  open IsBlockchain spec-IsBlockchain public using (producer; slotOf)
 
   honest-nodes-blockchain : ∀ {p} → p ∈ honest-nodes → IsBlockchain (all-nodes p)
   honest-nodes-blockchain p-honest =
@@ -65,8 +58,8 @@ record Safety : Type₂ where
           → bciQueryType bci
   query bci {p} _ (((_ , s , tt) , tt) , _) honest-p = proj₁ (queryCompute bci (⨂ᴷ-sub-state p s))
     where
-      open IsBlockchain (honest-nodes-blockchain honest-p)
-      open IsConstrained isConstrained
+      module IB = IsBlockchain (honest-nodes-blockchain honest-p)
+      open IsConstrained IB.isConstrained
 
   getChain = query Chain
   getSlot  = query Slot

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -1,19 +1,20 @@
 {-# OPTIONS --safe #-}
 
-open import Leios.Config
 open import Leios.Prelude hiding (id; _⊗_)
 
 open import CategoricalCrypto hiding (id; _∘_)
 
-module Leios.Safety (Block : Type) where
+module Blockchain.Safety (Block : Type) where
 
 -- | Type of things we can query from a honest node
 data BlockChainInfo : Type where
   Chain : BlockChainInfo
+  Slot  : BlockChainInfo
 
 -- | Type for responses given a specific query
 bciQueryType : BlockChainInfo → Type
 bciQueryType Chain = List Block
+bciQueryType Slot  = ℕ
 
 record IsBlockchain {A B : Channel} (m : Machine A B) : Type₂ where
   field 
@@ -68,6 +69,7 @@ record Safety : Type₂ where
       open IsConstrained isConstrained
 
   getChain = query Chain
+  getSlot  = query Slot
 
   safeState : {A : Channel} → ℕ → (E : Environment A) → Machine.State (protocol E) → Type
   safeState k E S =

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -5,7 +5,7 @@ open import Leios.Prelude hiding (id; _⊗_)
 
 open import CategoricalCrypto hiding (id; _∘_)
 
-module Leios.Safety (Block : Type) where
+module Blockchain.Safety (Block : Type) where
 
 -- | Type of things we can query from a honest node
 data BlockChainInfo : Type where

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -13,7 +13,7 @@ record Safety : Type₂ where
     -- Number of involved nodes
     n                        : ℕ
 
-  open IsBC Block (Fin n) public
+  open IsBC (Fin n) public
 
   field
     -- Communication channels involved in the network
@@ -21,7 +21,7 @@ record Safety : Type₂ where
     -- Machine describing the behavior of the honest nodes
     honest-node-spec         : Machine Network (IO ⊗₀ Adv)
     -- The spec can be queried in the right ways
-    spec-IsBlockchain        : IsBlockchain honest-node-spec
+    spec-IsBlockchain        : IsBlockchain Block honest-node-spec
     -- Channels for all nodes
     IOF AdvF                 : Fin n → Channel
     -- All the nodes, including honest nodes and adversaries
@@ -35,9 +35,9 @@ record Safety : Type₂ where
 
   open IsBlockchain spec-IsBlockchain public using (producer; slotOf)
 
-  honest-nodes-blockchain : ∀ {p} → p ∈ honest-nodes → IsBlockchain (all-nodes p)
+  honest-nodes-blockchain : ∀ {p} → p ∈ honest-nodes → IsBlockchain Block (all-nodes p)
   honest-nodes-blockchain p-honest =
-    ≡ᴹ-subst IsBlockchain (≡ᴹ-sym (honest-nodes-≡-spec p-honest)) spec-IsBlockchain
+    ≡ᴹ-subst (IsBlockchain Block) (≡ᴹ-sym (honest-nodes-≡-spec p-honest)) spec-IsBlockchain
 
   -- Combination of all the nodes together
   nodes : Machine (n ⨂ⁿ Network) (⨂ IOF ⊗₀ ⨂ AdvF)
@@ -50,7 +50,7 @@ record Safety : Type₂ where
   protocol : ∀ {A} → Environment A → Machine I A
   protocol E = E CategoricalCrypto.∘ (nodes ∘ᴷ network)
 
-  query : (bci : BlockChainInfo)
+  query : (bci : BlockChainInfo Block)
           {p : Fin n} {A : Channel}
           (E : Environment A)
           → Machine.State (protocol E)

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -18,10 +18,13 @@ record Spec (Block : Type) (n : ℕ) (Network : Channel) : Type₂ where
 
 -- | Deployment of a spec across `n` nodes. Honest nodes must behave
 -- according to `spec`, others can be completely arbitrary.
-record Deployment {Block : Type} {n : ℕ} {Network : Channel}
-                        (spec : Spec Block n Network) : Type₂ where
-  open Spec spec
-  open IsBC (Fin n)
+record Deployment (Block : Type) : Type₂ where
+  field
+    n       : ℕ
+    Network : Channel
+    spec    : Spec Block n Network
+  open Spec spec public
+  open IsBC (Fin n) public
   field
     NAdv                : Channel
     IOF AdvF            : Fin n → Channel
@@ -66,16 +69,6 @@ record Deployment {Block : Type} {n : ℕ} {Network : Channel}
 
   safety : ℕ → Type₁
   safety k = ∀ {A} (E : Environment A) → Invariant (protocol E) (safeState k E)
-
--- | Bundled `Deployment`
-record Safety (Block : Type) : Type₂ where
-  field
-    n          : ℕ
-    Network    : Channel
-    spec       : Spec Block n Network
-    deployment : Deployment spec
-  open Spec spec public
-  open Deployment deployment public
 
 -- | Witness that one `Spec` extends a given base `Spec`
 record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -10,18 +10,18 @@ module Blockchain.Safety where
 
 -- | The single-node blockchain spec: one machine that answers blockchain
 -- queries, plus its `IsBlockchain` evidence.
-record SafetySpec (Block : Type) (n : ℕ) (Network : Channel) : Type₂ where
+record Spec (Block : Type) (n : ℕ) (Network : Channel) : Type₂ where
   field
     IO Adv            : Channel
     honest-node-spec  : Machine Network (IO ⊗₀ Adv)
     spec-IsBlockchain : IsBC.IsBlockchain (Fin n) Block honest-node-spec
   open IsBC.IsBlockchain spec-IsBlockchain public using (producer; slotOf)
 
--- | Deployment of a spec across `n` nodes.  Depends on `SafetySpec` only
+-- | Deployment of a spec across `n` nodes.  Depends on `Spec` only
 -- via `honest-node-spec` (used in `honest-nodes-≡-spec`).
-record SafetyDeployment {Block : Type} {n : ℕ} {Network : Channel}
-                        (spec : SafetySpec Block n Network) : Type₂ where
-  open SafetySpec spec
+record Deployment {Block : Type} {n : ℕ} {Network : Channel}
+                        (spec : Spec Block n Network) : Type₂ where
+  open Spec spec
   open IsBC (Fin n)
   field
     NAdv                : Channel
@@ -74,19 +74,19 @@ record Safety (Block : Type) : Type₂ where
   field
     n          : ℕ
     Network    : Channel
-    spec       : SafetySpec Block n Network
-    deployment : SafetyDeployment spec
-  open SafetySpec spec public
-  open SafetyDeployment deployment public
+    spec       : Spec Block n Network
+    deployment : Deployment spec
+  open Spec spec public
+  open Deployment deployment public
 
--- | Witness that an ext `SafetySpec` extends some base honest-node spec:
+-- | Witness that an ext `Spec` extends some base honest-node spec:
 -- bundles the base-side spec, the channel/layer equipment, and the block-level
 -- projection.  Everything both `Safety.Transfer` and `Liveness.Transfer`
 -- need; Liveness additionally takes `producer-compat`/`slotOf-compat` as
 -- extra module parameters.
 record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}
-                   (ext-spec : SafetySpec BlockExt n Network) : Type₂ where
-  open SafetySpec ext-spec using (IO; Adv)
+                   (ext-spec : Spec BlockExt n Network) : Type₂ where
+  open Spec ext-spec using (IO; Adv)
   field
     base-IO base-Adv      : Channel
     base-honest-node-spec : Machine Network (base-IO ⊗₀ base-Adv)
@@ -96,7 +96,7 @@ record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}
     getBaseBlock          : BlockExt → BlockBase
     getBaseBlock-inj      : Injective _≡_ _≡_ getBaseBlock
 
-  base-spec : SafetySpec BlockBase n Network
+  base-spec : Spec BlockBase n Network
   base-spec = record
     { IO                = base-IO
     ; Adv               = base-Adv

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -79,27 +79,18 @@ record Safety (Block : Type) : Type₂ where
   open Spec spec public
   open Deployment deployment public
 
--- | Witness that an ext `Spec` extends some base honest-node spec:
--- bundles the base-side spec, the channel/layer equipment, and the block-level
--- projection.  Everything both `Safety.Transfer` and `Liveness.Transfer`
--- need; Liveness additionally takes `producer-compat`/`slotOf-compat` as
--- extra module parameters.
+-- | Witness that an ext `Spec` extends a given base `Spec`: bundles the
+-- channel/layer equipment and the block-level projection.  Everything both
+-- `Safety.Transfer` and `Liveness.Transfer` need; Liveness additionally takes
+-- `producer-compat`/`slotOf-compat` as extra module parameters.
 record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}
-                   (ext-spec : Spec BlockExt n Network) : Type₂ where
-  open Spec ext-spec using (IO; Adv)
+                   (base-spec : Spec BlockBase n Network)
+                   (ext-spec  : Spec BlockExt  n Network) : Type₂ where
+  private
+    module B = Spec base-spec
+    module E = Spec ext-spec
   field
-    base-IO base-Adv      : Channel
-    base-honest-node-spec : Machine Network (base-IO ⊗₀ base-Adv)
-    base-IsBlockchain     : IsBC.IsBlockchain (Fin n) BlockBase base-honest-node-spec
-    ext-Adv≡base-Adv      : Adv ≡ base-Adv
-    ext-layer             : Machine base-IO (IO ⊗₀ I)
-    getBaseBlock          : BlockExt → BlockBase
-    getBaseBlock-inj      : Injective _≡_ _≡_ getBaseBlock
-
-  base-spec : Spec BlockBase n Network
-  base-spec = record
-    { IO                = base-IO
-    ; Adv               = base-Adv
-    ; honest-node-spec  = base-honest-node-spec
-    ; spec-IsBlockchain = base-IsBlockchain
-    }
+    ext-Adv≡base-Adv : E.Adv ≡ B.Adv
+    ext-layer        : Machine B.IO (E.IO ⊗₀ I)
+    getBaseBlock     : BlockExt → BlockBase
+    getBaseBlock-inj : Injective _≡_ _≡_ getBaseBlock

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -92,5 +92,13 @@ record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}
   field
     ext-Adv≡base-Adv : E.Adv ≡ B.Adv
     ext-layer        : Machine B.IO (E.IO ⊗₀ I)
+    -- The ext honest-node spec factors through the base honest-node spec via
+    -- `ext-layer`, modulo the `Adv`-channel equality.  This is the equational
+    -- core of "ext extends base" and lets `Safety.Transfer` derive
+    -- `single-protocol-≡` from this record rather than asking for it.
+    is-extension : idᴷ ∘ᴷ E.honest-node-spec
+                 ≡ subst (λ A → Machine Network (E.IO ⊗₀ (A ⊗₀ I)))
+                         (sym ext-Adv≡base-Adv)
+                         (ext-layer ∘ᴷ B.honest-node-spec)
     getBaseBlock     : BlockExt → BlockBase
     getBaseBlock-inj : Injective _≡_ _≡_ getBaseBlock

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -6,25 +6,30 @@ open import CategoricalCrypto hiding (id; _∘_)
 
 import Blockchain.IsBlockchain as IsBC
 
-module Blockchain.Safety (Block : Type) where
+module Blockchain.Safety where
 
-record Safety : Type₂ where
+-- | The single-node blockchain spec: one machine that answers blockchain
+-- queries, plus its `IsBlockchain` evidence.
+record SafetySpec (Block : Type) (n : ℕ) (Network : Channel) : Type₂ where
   field
-    n                        : ℕ
+    IO Adv            : Channel
+    honest-node-spec  : Machine Network (IO ⊗₀ Adv)
+    spec-IsBlockchain : IsBC.IsBlockchain (Fin n) Block honest-node-spec
+  open IsBC.IsBlockchain spec-IsBlockchain public using (producer; slotOf)
 
-  open IsBC (Fin n) public
-
+-- | Deployment of a spec across `n` nodes.  Depends on `SafetySpec` only
+-- via `honest-node-spec` (used in `honest-nodes-≡-spec`).
+record SafetyDeployment {Block : Type} {n : ℕ} {Network : Channel}
+                        (spec : SafetySpec Block n Network) : Type₂ where
+  open SafetySpec spec
+  open IsBC (Fin n)
   field
-    IO Adv NAdv Network      : Channel
-    honest-node-spec         : Machine Network (IO ⊗₀ Adv)
-    spec-IsBlockchain        : IsBlockchain Block honest-node-spec
-    IOF AdvF                 : Fin n → Channel
-    all-nodes                : (p : Fin n) → Machine Network (IOF p ⊗₀ AdvF p)
-    honest-nodes             : ℙ (Fin n)
-    honest-nodes-≡-spec      : ∀ {p} → p ∈ honest-nodes → all-nodes p ≡ᴹ honest-node-spec
-    network                  : Machine I (n ⨂ⁿ Network ⊗₀ NAdv)
-
-  open IsBlockchain spec-IsBlockchain public using (producer; slotOf)
+    NAdv                : Channel
+    IOF AdvF            : Fin n → Channel
+    all-nodes           : (p : Fin n) → Machine Network (IOF p ⊗₀ AdvF p)
+    honest-nodes        : ℙ (Fin n)
+    honest-nodes-≡-spec : ∀ {p} → p ∈ honest-nodes → all-nodes p ≡ᴹ honest-node-spec
+    network             : Machine I (n ⨂ⁿ Network ⊗₀ NAdv)
 
   honest-nodes-blockchain : ∀ {p} → p ∈ honest-nodes → IsBlockchain Block (all-nodes p)
   honest-nodes-blockchain p-honest =
@@ -62,3 +67,39 @@ record Safety : Type₂ where
 
   safety : ℕ → Type₁
   safety k = ∀ {A} (E : Environment A) → Invariant (protocol E) (safeState k E)
+
+-- | Combined single-/multi-node record; kept as the user-facing API.  The
+-- public re-opens below make every old `Safety.X` projection resolve.
+record Safety (Block : Type) : Type₂ where
+  field
+    n          : ℕ
+    Network    : Channel
+    spec       : SafetySpec Block n Network
+    deployment : SafetyDeployment spec
+  open SafetySpec spec public
+  open SafetyDeployment deployment public
+
+-- | Witness that an ext `SafetySpec` extends some base honest-node spec:
+-- bundles the base-side spec, the channel/layer equipment, and the block-level
+-- projection.  Everything both `Safety.Transfer` and `Liveness.Transfer`
+-- need; Liveness additionally takes `producer-compat`/`slotOf-compat` as
+-- extra module parameters.
+record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}
+                   (ext-spec : SafetySpec BlockExt n Network) : Type₂ where
+  open SafetySpec ext-spec using (IO; Adv)
+  field
+    base-IO base-Adv      : Channel
+    base-honest-node-spec : Machine Network (base-IO ⊗₀ base-Adv)
+    base-IsBlockchain     : IsBC.IsBlockchain (Fin n) BlockBase base-honest-node-spec
+    ext-Adv≡base-Adv      : Adv ≡ base-Adv
+    ext-layer             : Machine base-IO (IO ⊗₀ I)
+    getBaseBlock          : BlockExt → BlockBase
+    getBaseBlock-inj      : Injective _≡_ _≡_ getBaseBlock
+
+  base-spec : SafetySpec BlockBase n Network
+  base-spec = record
+    { IO                = base-IO
+    ; Adv               = base-Adv
+    ; honest-node-spec  = base-honest-node-spec
+    ; spec-IsBlockchain = base-IsBlockchain
+    }

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -10,27 +10,18 @@ module Blockchain.Safety (Block : Type) where
 
 record Safety : Type₂ where
   field
-    -- Number of involved nodes
     n                        : ℕ
 
   open IsBC (Fin n) public
 
   field
-    -- Communication channels involved in the network
     IO Adv NAdv Network      : Channel
-    -- Machine describing the behavior of the honest nodes
     honest-node-spec         : Machine Network (IO ⊗₀ Adv)
-    -- The spec can be queried in the right ways
     spec-IsBlockchain        : IsBlockchain Block honest-node-spec
-    -- Channels for all nodes
     IOF AdvF                 : Fin n → Channel
-    -- All the nodes, including honest nodes and adversaries
     all-nodes                : (p : Fin n) → Machine Network (IOF p ⊗₀ AdvF p)
-    -- All the honest nodes
-    honest-nodes             : ℙ (Fin n) -- Nodes behaving like the honest spec
-    -- Proofs that each of the honest nodes behave like the specification
+    honest-nodes             : ℙ (Fin n)
     honest-nodes-≡-spec      : ∀ {p} → p ∈ honest-nodes → all-nodes p ≡ᴹ honest-node-spec
-    -- The network machine
     network                  : Machine I (n ⨂ⁿ Network ⊗₀ NAdv)
 
   open IsBlockchain spec-IsBlockchain public using (producer; slotOf)
@@ -39,14 +30,12 @@ record Safety : Type₂ where
   honest-nodes-blockchain p-honest =
     ≡ᴹ-subst (IsBlockchain Block) (≡ᴹ-sym (honest-nodes-≡-spec p-honest)) spec-IsBlockchain
 
-  -- Combination of all the nodes together
   nodes : Machine (n ⨂ⁿ Network) (⨂ IOF ⊗₀ ⨂ AdvF)
   nodes = ⨂ᴷ all-nodes
 
   Environment : Channel → Type₁
   Environment A = Machine (⨂ IOF ⊗₀ (NAdv ⊗₀ ⨂ AdvF)) A
 
-  -- Composition of the nodes and the network
   protocol : ∀ {A} → Environment A → Machine I A
   protocol E = E CategoricalCrypto.∘ (nodes ∘ᴷ network)
 

--- a/formal-spec/Blockchain/Safety.agda
+++ b/formal-spec/Blockchain/Safety.agda
@@ -8,8 +8,7 @@ import Blockchain.IsBlockchain as IsBC
 
 module Blockchain.Safety where
 
--- | The single-node blockchain spec: one machine that answers blockchain
--- queries, plus its `IsBlockchain` evidence.
+-- | A specification for a blockchain
 record Spec (Block : Type) (n : ℕ) (Network : Channel) : Type₂ where
   field
     IO Adv            : Channel
@@ -17,8 +16,8 @@ record Spec (Block : Type) (n : ℕ) (Network : Channel) : Type₂ where
     spec-IsBlockchain : IsBC.IsBlockchain (Fin n) Block honest-node-spec
   open IsBC.IsBlockchain spec-IsBlockchain public using (producer; slotOf)
 
--- | Deployment of a spec across `n` nodes.  Depends on `Spec` only
--- via `honest-node-spec` (used in `honest-nodes-≡-spec`).
+-- | Deployment of a spec across `n` nodes. Honest nodes must behave
+-- according to `spec`, others can be completely arbitrary.
 record Deployment {Block : Type} {n : ℕ} {Network : Channel}
                         (spec : Spec Block n Network) : Type₂ where
   open Spec spec
@@ -68,8 +67,7 @@ record Deployment {Block : Type} {n : ℕ} {Network : Channel}
   safety : ℕ → Type₁
   safety k = ∀ {A} (E : Environment A) → Invariant (protocol E) (safeState k E)
 
--- | Combined single-/multi-node record; kept as the user-facing API.  The
--- public re-opens below make every old `Safety.X` projection resolve.
+-- | Bundled `Deployment`
 record Safety (Block : Type) : Type₂ where
   field
     n          : ℕ
@@ -79,10 +77,7 @@ record Safety (Block : Type) : Type₂ where
   open Spec spec public
   open Deployment deployment public
 
--- | Witness that an ext `Spec` extends a given base `Spec`: bundles the
--- channel/layer equipment and the block-level projection.  Everything both
--- `Safety.Transfer` and `Liveness.Transfer` need; Liveness additionally takes
--- `producer-compat`/`slotOf-compat` as extra module parameters.
+-- | Witness that one `Spec` extends a given base `Spec`
 record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}
                    (base-spec : Spec BlockBase n Network)
                    (ext-spec  : Spec BlockExt  n Network) : Type₂ where
@@ -90,15 +85,12 @@ record IsExtension {BlockBase BlockExt : Type} {n : ℕ} {Network : Channel}
     module B = Spec base-spec
     module E = Spec ext-spec
   field
-    ext-Adv≡base-Adv : E.Adv ≡ B.Adv
     ext-layer        : Machine B.IO (E.IO ⊗₀ I)
-    -- The ext honest-node spec factors through the base honest-node spec via
-    -- `ext-layer`, modulo the `Adv`-channel equality.  This is the equational
-    -- core of "ext extends base" and lets `Safety.Transfer` derive
-    -- `single-protocol-≡` from this record rather than asking for it.
+    getBaseBlock     : BlockExt → BlockBase
+
+    ext-Adv≡base-Adv : E.Adv ≡ B.Adv
+    getBaseBlock-inj : Injective _≡_ _≡_ getBaseBlock
     is-extension : idᴷ ∘ᴷ E.honest-node-spec
                  ≡ subst (λ A → Machine Network (E.IO ⊗₀ (A ⊗₀ I)))
                          (sym ext-Adv≡base-Adv)
                          (ext-layer ∘ᴷ B.honest-node-spec)
-    getBaseBlock     : BlockExt → BlockBase
-    getBaseBlock-inj : Injective _≡_ _≡_ getBaseBlock

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -30,21 +30,17 @@ module B = Spec base-spec
 open IsExtension extension
 open ChannelCat cc
 
--- On honest nodes, the per-participant channels agree with the ext spec's
--- `IO`/`Adv` channels.  Derived from `Ext.honest-nodes-≡-spec`.
 honest-IOF : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → Ext.IOF p ≡ Ext.IO
 honest-IOF hp = ⊗-injectiveˡ (_≡ᴹ_.B≡D (Ext.honest-nodes-≡-spec hp))
 
 honest-AdvF : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → Ext.AdvF p ≡ B.Adv
 honest-AdvF hp = trans (⊗-injectiveʳ (_≡ᴹ_.B≡D (Ext.honest-nodes-≡-spec hp))) ext-Adv≡base-Adv
 
--- Per-participant base IO channel: `B.IO` on honest nodes, else ext IOF.
 base-IOF : Fin Ext.n → Channel
 base-IOF p = case p ∈? Ext.honest-nodes of λ where
   (yes _) → B.IO
   (no  _) → Ext.IOF p
 
--- Honest nodes are replaced by `B.honest-node-spec`; dishonest nodes are unchanged.
 base-all-nodes : (p : Fin Ext.n) → Machine Ext.Network (base-IOF p ⊗₀ Ext.AdvF p)
 base-all-nodes p with p ∈? Ext.honest-nodes
 ... | yes hp = subst (λ x → Machine Ext.Network (B.IO ⊗₀ x)) (sym (honest-AdvF hp)) B.honest-node-spec
@@ -61,15 +57,11 @@ base-honest-≡-spec {p} hp with p ∈? Ext.honest-nodes
 ... | yes hp' = subst-≡ᴹ (sym (honest-AdvF hp')) B.honest-node-spec
 ... | no ¬hp  = contradiction hp ¬hp
 
--- Derived per-participant extension piece: honest nodes get `ext-layer`
--- (transported from `Ext.IO` to `Ext.IOF p`), dishonest nodes get identity
--- (with `base-IOF p` definitionally `Ext.IOF p`).
 extPart : (p : Fin Ext.n) → Machine (base-IOF p) (Ext.IOF p ⊗₀ I)
 extPart p with p ∈? Ext.honest-nodes
 ... | yes hp = subst (λ x → Machine B.IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-layer
 ... | no  _  = idᴷ
 
--- The derived base `Deployment` (over `base-spec`).
 base-deployment : Deployment base-spec
 base-deployment = record
   { NAdv                = Ext.NAdv
@@ -81,7 +73,6 @@ base-deployment = record
   ; network             = Ext.network
   }
 
--- The derived base `Safety` record.
 base : Safety BlockBase
 base = record
   { n          = Ext.n
@@ -92,10 +83,6 @@ base = record
 
 module Base = Safety base
 
--- Every ext node factors as `extPart p ∘ᴷ base-all-nodes p`.  For honest
--- nodes this follows from `is-extension` via `∘ᴷ-cong-≡ᴹ` (a ChannelCat
--- axiom); for dishonest nodes both sides definitionally reduce to the
--- same `idᴷ ∘ᴷ Ext.all-nodes p`.
 single-protocol-≡ : ∀ p → idᴷ ∘ᴷ Ext.all-nodes p ≡ extPart p ∘ᴷ base-all-nodes p
 single-protocol-≡ p with p ∈? Ext.honest-nodes
 ... | no ¬hp = refl
@@ -109,7 +96,6 @@ single-protocol-≡ p with p ∈? Ext.honest-nodes
 
 module Main where
 
-  -- | Translation from extended protocols to base protocols.
   module _ {A : Channel} (E : Ext.Environment A) where
 
     -- this is a structure isomorphism
@@ -118,7 +104,6 @@ module Main where
       (⨂ Ext.IOF ⊗₀ (Ext.NAdv ⊗₀ ⨂ Ext.AdvF))
     transId = insert-id-helper Ext.AdvF ∘ (⨂-absorb-env-helper Ext.IOF)
 
-    -- This is `E`, but we absorb the `extPart` part of each participant.
     transEnv : Base.Environment A
     transEnv = E ∘ transId ∘ ⨂ᴷ extPart ⊗₁ CC.id
 
@@ -142,7 +127,6 @@ module Main where
       → Trace (Base.protocol transEnv) (transState s₁) (transState s₂)
     transTrace = Trace-subst transProtocol
 
-  -- | Chain lemma: the base chain is the `getBaseBlock`-projection of the ext chain.
   ChainLemma-ty : ∀ {A : Channel} → Ext.Environment A → Type
   ChainLemma-ty {A} E = ∀ {p : Fin Ext.n} {s} (p-honest : p ∈ Ext.honest-nodes)
     → Base.getChain (transEnv E) (transState E s) p-honest

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -29,7 +29,7 @@ module Blockchain.Safety.Transfer
   -- Base spec + evidence.
   (base-IO base-Adv     : Channel)
   (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
-  (base-IsBlockchain    : IsBC.IsBlockchain BlockBase (Fin (Safety.n ext)) base-spec)
+  (base-IsBlockchain    : IsBC.IsBlockchain (Fin (Safety.n ext)) BlockBase base-spec)
   -- The ext and base adversary channels agree.  Together with
   -- `Ext.honest-nodes-≡-spec` this lets us swap the honest ext node for
   -- `base-spec` on the base side.

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -7,8 +7,8 @@ open import Leios.ChannelCat
 
 open import CategoricalCrypto hiding (id)
 import CategoricalCrypto as CC
+open import CategoricalCrypto.Ext
 
-import Relation.Binary.HeterogeneousEquality as H
 import Relation.Binary.Reasoning.PartialOrder
 open import Relation.Binary using (Poset)
 
@@ -91,36 +91,6 @@ base = record
   }
 
 module Base = Safety base
-
-private
-  -- Transitivity of `_≡ᴹ_`.
-  ≡ᴹ-trans : ∀ {A₁ A₂ A₃ B₁ B₂ B₃}
-             {M₁ : Machine A₁ B₁} {M₂ : Machine A₂ B₂} {M₃ : Machine A₃ B₃}
-           → M₁ ≡ᴹ M₂ → M₂ ≡ᴹ M₃ → M₁ ≡ᴹ M₃
-  ≡ᴹ-trans record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl }
-           record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl }
-    = ≡ᴹ-refl
-
-  -- When both sides already have the same type, `_≡ᴹ_` collapses to `_≡_`.
-  ≡ᴹ→≡ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ᴹ M₂ → M₁ ≡ M₂
-  ≡ᴹ→≡ record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl } = refl
-
-  -- Inclusion `_≡_ → _≡ᴹ_` at matching types.
-  ≡→≡ᴹ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ M₂ → M₁ ≡ᴹ M₂
-  ≡→≡ᴹ refl = ≡ᴹ-refl
-
-  -- `subst` along a channel equality preserves the machine up to `_≡ᴹ_`
-  -- (variant of `subst-≡ᴹ` where the channel equation affects only the
-  -- output type).
-  subst-≡ᴹ-out : ∀ {x y} {A : Channel} {B : Channel → Channel}
-               → (eq : x ≡ y) (M : Machine A (B x))
-               → subst (λ c → Machine A (B c)) eq M ≡ᴹ M
-  subst-≡ᴹ-out refl _ = ≡ᴹ-refl
-
-  -- `idᴷ` instantiated at different (but propositionally equal) channels
-  -- are `_≡ᴹ_`.
-  idᴷ-cong-≡ᴹ : ∀ {A B} → A ≡ B → _≡ᴹ_ (idᴷ {A = A}) (idᴷ {A = B})
-  idᴷ-cong-≡ᴹ refl = ≡ᴹ-refl
 
 -- Every ext node factors as `extPart p ∘ᴷ base-all-nodes p`.  For honest
 -- nodes this follows from `is-extension` via `∘ᴷ-cong-≡ᴹ` (a ChannelCat

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --safe #-}
 
 open import Leios.Prelude hiding (id; _⊗_; _∘_)
-open import Leios.Safety
+open import Blockchain.Safety
 open import Leios.ChannelCat
 
 open import CategoricalCrypto hiding (id)
@@ -19,7 +19,7 @@ open import Relation.Binary using (Poset)
 --
 -- The base-side Safety record is derived internally: honest nodes run
 -- `base-spec`, dishonest nodes inherit their original protocol from `ext`.
-module Leios.Safety.Transfer
+module Blockchain.Safety.Transfer
   {BlockExt BlockBase   : Type}
   (getBaseBlock         : BlockExt → BlockBase)
   (getBaseBlock-inj     : Injective _≡_ _≡_ getBaseBlock)

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -8,6 +8,7 @@ open import Leios.ChannelCat
 open import CategoricalCrypto hiding (id)
 import CategoricalCrypto as CC
 
+import Relation.Binary.HeterogeneousEquality as H
 import Relation.Binary.Reasoning.PartialOrder
 open import Relation.Binary using (Poset)
 
@@ -91,14 +92,52 @@ base = record
 
 module Base = Safety base
 
--- The remaining transfer requires the caller to prove that every ext node
--- factors as `extPart p ∘ᴷ base-all-nodes p`.  For honest nodes this follows
--- from `is-extension` (with some type-bridging work); for dishonest nodes
--- both sides definitionally reduce to `idᴷ ∘ᴷ Ext.all-nodes p`.  The actual
--- derivation is deferred to the caller for now.
-module Main (single-protocol-≡ : ∀ p
-                               → idᴷ ∘ᴷ Ext.all-nodes p
-                               ≡ extPart p ∘ᴷ base-all-nodes p) where
+private
+  -- Transitivity of `_≡ᴹ_`.
+  ≡ᴹ-trans : ∀ {A₁ A₂ A₃ B₁ B₂ B₃}
+             {M₁ : Machine A₁ B₁} {M₂ : Machine A₂ B₂} {M₃ : Machine A₃ B₃}
+           → M₁ ≡ᴹ M₂ → M₂ ≡ᴹ M₃ → M₁ ≡ᴹ M₃
+  ≡ᴹ-trans record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl }
+           record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl }
+    = ≡ᴹ-refl
+
+  -- When both sides already have the same type, `_≡ᴹ_` collapses to `_≡_`.
+  ≡ᴹ→≡ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ᴹ M₂ → M₁ ≡ M₂
+  ≡ᴹ→≡ record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl } = refl
+
+  -- Inclusion `_≡_ → _≡ᴹ_` at matching types.
+  ≡→≡ᴹ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ M₂ → M₁ ≡ᴹ M₂
+  ≡→≡ᴹ refl = ≡ᴹ-refl
+
+  -- `subst` along a channel equality preserves the machine up to `_≡ᴹ_`
+  -- (variant of `subst-≡ᴹ` where the channel equation affects only the
+  -- output type).
+  subst-≡ᴹ-out : ∀ {x y} {A : Channel} {B : Channel → Channel}
+               → (eq : x ≡ y) (M : Machine A (B x))
+               → subst (λ c → Machine A (B c)) eq M ≡ᴹ M
+  subst-≡ᴹ-out refl _ = ≡ᴹ-refl
+
+  -- `idᴷ` instantiated at different (but propositionally equal) channels
+  -- are `_≡ᴹ_`.
+  idᴷ-cong-≡ᴹ : ∀ {A B} → A ≡ B → _≡ᴹ_ (idᴷ {A = A}) (idᴷ {A = B})
+  idᴷ-cong-≡ᴹ refl = ≡ᴹ-refl
+
+-- Every ext node factors as `extPart p ∘ᴷ base-all-nodes p`.  For honest
+-- nodes this follows from `is-extension` via `∘ᴷ-cong-≡ᴹ` (a ChannelCat
+-- axiom); for dishonest nodes both sides definitionally reduce to the
+-- same `idᴷ ∘ᴷ Ext.all-nodes p`.
+single-protocol-≡ : ∀ p → idᴷ ∘ᴷ Ext.all-nodes p ≡ extPart p ∘ᴷ base-all-nodes p
+single-protocol-≡ p with p ∈? Ext.honest-nodes
+... | no ¬hp = refl
+... | yes hp = ≡ᴹ→≡
+  (≡ᴹ-trans (∘ᴷ-cong-≡ᴹ (idᴷ-cong-≡ᴹ (honest-IOF hp))
+                        (Ext.honest-nodes-≡-spec hp))
+  (≡ᴹ-trans (≡→≡ᴹ is-extension)
+  (≡ᴹ-trans (subst-≡ᴹ-out (sym ext-Adv≡base-Adv) _)
+            (∘ᴷ-cong-≡ᴹ (≡ᴹ-sym (subst-≡ᴹ (sym (honest-IOF hp)) ext-layer))
+                        (≡ᴹ-sym (subst-≡ᴹ (sym (honest-AdvF hp)) B.honest-node-spec))))))
+
+module Main where
 
   -- | Translation from extended protocols to base protocols.
   module _ {A : Channel} (E : Ext.Environment A) where

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -92,8 +92,10 @@ base = record
 module Base = Safety base
 
 -- The remaining transfer requires the caller to prove that every ext node
--- factors as `extPart p ∘ᴷ base-all-nodes p`.  Since `extPart` is derived
--- above, this proof is stated in terms of the derived definition.
+-- factors as `extPart p ∘ᴷ base-all-nodes p`.  For honest nodes this follows
+-- from `is-extension` (with some type-bridging work); for dishonest nodes
+-- both sides definitionally reduce to `idᴷ ∘ᴷ Ext.all-nodes p`.  The actual
+-- derivation is deferred to the caller for now.
 module Main (single-protocol-≡ : ∀ p
                                → idᴷ ∘ᴷ Ext.all-nodes p
                                ≡ extPart p ∘ᴷ base-all-nodes p) where

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -66,8 +66,8 @@ extPart p with p ∈? Ext.honest-nodes
 ... | yes hp = subst (λ x → Machine base-IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-layer
 ... | no  _  = idᴷ
 
--- The derived base `SafetyDeployment` (over `base-spec`).
-base-deployment : SafetyDeployment base-spec
+-- The derived base `Deployment` (over `base-spec`).
+base-deployment : Deployment base-spec
 base-deployment = record
   { NAdv                = Ext.NAdv
   ; IOF                 = base-IOF

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -2,6 +2,7 @@
 
 open import Leios.Prelude hiding (id; _⊗_; _∘_)
 open import Blockchain.Safety
+import Blockchain.IsBlockchain as IsBC
 open import Leios.ChannelCat
 
 open import CategoricalCrypto hiding (id)
@@ -28,7 +29,7 @@ module Blockchain.Safety.Transfer
   -- Base spec + evidence.
   (base-IO base-Adv     : Channel)
   (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
-  (base-IsBlockchain    : IsBlockchain BlockBase base-spec)
+  (base-IsBlockchain    : IsBC.IsBlockchain BlockBase (Fin (Safety.n ext)) base-spec)
   -- The ext and base adversary channels agree.  Together with
   -- `Ext.honest-nodes-≡-spec` this lets us swap the honest ext node for
   -- `base-spec` on the base side.

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -19,11 +19,13 @@ open import Relation.Binary using (Poset)
 module Blockchain.Safety.Transfer
   {BlockExt BlockBase : Type}
   (ext                : Safety BlockExt)
+  (let module Ext = Safety ext)
+  (base-spec          : Spec BlockBase Ext.n Ext.Network)
   (cc                 : ChannelCat)
-  (extension          : IsExtension {BlockBase} (Safety.spec ext))
+  (extension          : IsExtension base-spec (Safety.spec ext))
   where
 
-module Ext = Safety ext
+module B = Spec base-spec
 open IsExtension extension
 open ChannelCat cc
 
@@ -32,19 +34,19 @@ open ChannelCat cc
 honest-IOF : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → Ext.IOF p ≡ Ext.IO
 honest-IOF hp = ⊗-injectiveˡ (_≡ᴹ_.B≡D (Ext.honest-nodes-≡-spec hp))
 
-honest-AdvF : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → Ext.AdvF p ≡ base-Adv
+honest-AdvF : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → Ext.AdvF p ≡ B.Adv
 honest-AdvF hp = trans (⊗-injectiveʳ (_≡ᴹ_.B≡D (Ext.honest-nodes-≡-spec hp))) ext-Adv≡base-Adv
 
--- Per-participant base IO channel: `base-IO` on honest nodes, else ext IOF.
+-- Per-participant base IO channel: `B.IO` on honest nodes, else ext IOF.
 base-IOF : Fin Ext.n → Channel
 base-IOF p = case p ∈? Ext.honest-nodes of λ where
-  (yes _) → base-IO
+  (yes _) → B.IO
   (no  _) → Ext.IOF p
 
--- Honest nodes are replaced by `base-honest-node-spec`; dishonest nodes are unchanged.
+-- Honest nodes are replaced by `B.honest-node-spec`; dishonest nodes are unchanged.
 base-all-nodes : (p : Fin Ext.n) → Machine Ext.Network (base-IOF p ⊗₀ Ext.AdvF p)
 base-all-nodes p with p ∈? Ext.honest-nodes
-... | yes hp = subst (λ x → Machine Ext.Network (base-IO ⊗₀ x)) (sym (honest-AdvF hp)) base-honest-node-spec
+... | yes hp = subst (λ x → Machine Ext.Network (B.IO ⊗₀ x)) (sym (honest-AdvF hp)) B.honest-node-spec
 ... | no  _  = Ext.all-nodes p
 
 private
@@ -53,9 +55,9 @@ private
   subst-≡ᴹ refl _ = ≡ᴹ-refl
 
 base-honest-≡-spec : {p : Fin Ext.n} → p ∈ Ext.honest-nodes
-                   → base-all-nodes p ≡ᴹ base-honest-node-spec
+                   → base-all-nodes p ≡ᴹ B.honest-node-spec
 base-honest-≡-spec {p} hp with p ∈? Ext.honest-nodes
-... | yes hp' = subst-≡ᴹ (sym (honest-AdvF hp')) base-honest-node-spec
+... | yes hp' = subst-≡ᴹ (sym (honest-AdvF hp')) B.honest-node-spec
 ... | no ¬hp  = contradiction hp ¬hp
 
 -- Derived per-participant extension piece: honest nodes get `ext-layer`
@@ -63,7 +65,7 @@ base-honest-≡-spec {p} hp with p ∈? Ext.honest-nodes
 -- (with `base-IOF p` definitionally `Ext.IOF p`).
 extPart : (p : Fin Ext.n) → Machine (base-IOF p) (Ext.IOF p ⊗₀ I)
 extPart p with p ∈? Ext.honest-nodes
-... | yes hp = subst (λ x → Machine base-IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-layer
+... | yes hp = subst (λ x → Machine B.IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-layer
 ... | no  _  = idᴷ
 
 -- The derived base `Deployment` (over `base-spec`).

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -13,32 +13,18 @@ open import Relation.Binary using (Poset)
 
 -- | Generic safety transfer.
 --
--- Given an "extended" blockchain spec `ext`, a chain-projection `getBaseBlock`
--- into a "base" blockchain spec (injective), and a honest upper layer
--- witnessing the factoring of each honest ext node through the base spec,
--- safety of the derived base spec implies safety of the ext spec.
---
--- The base-side Safety record is derived internally: honest nodes run
--- `base-spec`, dishonest nodes inherit their original protocol from `ext`.
+-- Given an ext `Safety` and an `IsExtension` witness (the base-side spec,
+-- channel/layer equipment, and block-level projection), safety of the
+-- derived base `Safety` implies safety of the ext `Safety`.
 module Blockchain.Safety.Transfer
-  {BlockExt BlockBase   : Type}
-  (getBaseBlock         : BlockExt → BlockBase)
-  (getBaseBlock-inj     : Injective _≡_ _≡_ getBaseBlock)
-  (ext                  : Safety BlockExt)
-  (cc                   : ChannelCat)
-  -- Base spec + evidence.
-  (base-IO base-Adv     : Channel)
-  (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
-  (base-IsBlockchain    : IsBC.IsBlockchain (Fin (Safety.n ext)) BlockBase base-spec)
-  -- The ext and base adversary channels agree.  Together with
-  -- `Ext.honest-nodes-≡-spec` this lets us swap the honest ext node for
-  -- `base-spec` on the base side.
-  (ext-Adv≡base-Adv     : Safety.Adv ext ≡ base-Adv)
-  -- Honest upper layer: extends the base spec into the ext honest-node spec.
-  (ext-spec             : Machine base-IO (Safety.IO ext ⊗₀ I))
+  {BlockExt BlockBase : Type}
+  (ext                : Safety BlockExt)
+  (cc                 : ChannelCat)
+  (extension          : IsExtension {BlockBase} (Safety.spec ext))
   where
 
 module Ext = Safety ext
+open IsExtension extension
 open ChannelCat cc
 
 -- On honest nodes, the per-participant channels agree with the ext spec's
@@ -55,10 +41,10 @@ base-IOF p = case p ∈? Ext.honest-nodes of λ where
   (yes _) → base-IO
   (no  _) → Ext.IOF p
 
--- Honest nodes are replaced by `base-spec`; dishonest nodes are unchanged.
+-- Honest nodes are replaced by `base-honest-node-spec`; dishonest nodes are unchanged.
 base-all-nodes : (p : Fin Ext.n) → Machine Ext.Network (base-IOF p ⊗₀ Ext.AdvF p)
 base-all-nodes p with p ∈? Ext.honest-nodes
-... | yes hp = subst (λ x → Machine Ext.Network (base-IO ⊗₀ x)) (sym (honest-AdvF hp)) base-spec
+... | yes hp = subst (λ x → Machine Ext.Network (base-IO ⊗₀ x)) (sym (honest-AdvF hp)) base-honest-node-spec
 ... | no  _  = Ext.all-nodes p
 
 private
@@ -66,35 +52,39 @@ private
     → (M : Machine (A x) (B x)) → subst (λ x → Machine (A x) (B x)) eq M ≡ᴹ M
   subst-≡ᴹ refl _ = ≡ᴹ-refl
 
-base-honest-≡-spec : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → base-all-nodes p ≡ᴹ base-spec
+base-honest-≡-spec : {p : Fin Ext.n} → p ∈ Ext.honest-nodes
+                   → base-all-nodes p ≡ᴹ base-honest-node-spec
 base-honest-≡-spec {p} hp with p ∈? Ext.honest-nodes
-... | yes hp' = subst-≡ᴹ (sym (honest-AdvF hp')) base-spec
+... | yes hp' = subst-≡ᴹ (sym (honest-AdvF hp')) base-honest-node-spec
 ... | no ¬hp  = contradiction hp ¬hp
 
--- Derived per-participant extension piece: honest nodes get `ext-spec`
+-- Derived per-participant extension piece: honest nodes get `ext-layer`
 -- (transported from `Ext.IO` to `Ext.IOF p`), dishonest nodes get identity
 -- (with `base-IOF p` definitionally `Ext.IOF p`).
 extPart : (p : Fin Ext.n) → Machine (base-IOF p) (Ext.IOF p ⊗₀ I)
 extPart p with p ∈? Ext.honest-nodes
-... | yes hp = subst (λ x → Machine base-IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-spec
+... | yes hp = subst (λ x → Machine base-IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-layer
 ... | no  _  = idᴷ
 
--- The derived base Safety record.
-base : Safety BlockBase
-base = record
-  { n                   = Ext.n
-  ; IO                  = base-IO
-  ; Adv                 = base-Adv
-  ; NAdv                = Ext.NAdv
-  ; Network             = Ext.Network
-  ; honest-node-spec    = base-spec
-  ; spec-IsBlockchain   = base-IsBlockchain
+-- The derived base `SafetyDeployment` (over `base-spec`).
+base-deployment : SafetyDeployment base-spec
+base-deployment = record
+  { NAdv                = Ext.NAdv
   ; IOF                 = base-IOF
   ; AdvF                = Ext.AdvF
   ; all-nodes           = base-all-nodes
   ; honest-nodes        = Ext.honest-nodes
   ; honest-nodes-≡-spec = base-honest-≡-spec
   ; network             = Ext.network
+  }
+
+-- The derived base `Safety` record.
+base : Safety BlockBase
+base = record
+  { n          = Ext.n
+  ; Network    = Ext.Network
+  ; spec       = base-spec
+  ; deployment = base-deployment
   }
 
 module Base = Safety base

--- a/formal-spec/Blockchain/Safety/Transfer.agda
+++ b/formal-spec/Blockchain/Safety/Transfer.agda
@@ -14,16 +14,16 @@ open import Relation.Binary using (Poset)
 
 -- | Generic safety transfer.
 --
--- Given an ext `Safety` and an `IsExtension` witness (the base-side spec,
+-- Given an ext `Deployment` and an `IsExtension` witness (the base-side spec,
 -- channel/layer equipment, and block-level projection), safety of the
--- derived base `Safety` implies safety of the ext `Safety`.
+-- derived base `Deployment` implies safety of the ext `Deployment`.
 module Blockchain.Safety.Transfer
   {BlockExt BlockBase : Type}
-  (ext                : Safety BlockExt)
-  (let module Ext = Safety ext)
+  (ext                : Deployment BlockExt)
+  (let module Ext = Deployment ext)
   (base-spec          : Spec BlockBase Ext.n Ext.Network)
   (cc                 : ChannelCat)
-  (extension          : IsExtension base-spec (Safety.spec ext))
+  (extension          : IsExtension base-spec Ext.spec)
   where
 
 module B = Spec base-spec
@@ -62,9 +62,12 @@ extPart p with p ∈? Ext.honest-nodes
 ... | yes hp = subst (λ x → Machine B.IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-layer
 ... | no  _  = idᴷ
 
-base-deployment : Deployment base-spec
-base-deployment = record
-  { NAdv                = Ext.NAdv
+base : Deployment BlockBase
+base = record
+  { n                   = Ext.n
+  ; Network             = Ext.Network
+  ; spec                = base-spec
+  ; NAdv                = Ext.NAdv
   ; IOF                 = base-IOF
   ; AdvF                = Ext.AdvF
   ; all-nodes           = base-all-nodes
@@ -73,15 +76,7 @@ base-deployment = record
   ; network             = Ext.network
   }
 
-base : Safety BlockBase
-base = record
-  { n          = Ext.n
-  ; Network    = Ext.Network
-  ; spec       = base-spec
-  ; deployment = base-deployment
-  }
-
-module Base = Safety base
+module Base = Deployment base
 
 single-protocol-≡ : ∀ p → idᴷ ∘ᴷ Ext.all-nodes p ≡ extPart p ∘ᴷ base-all-nodes p
 single-protocol-≡ p with p ∈? Ext.honest-nodes

--- a/formal-spec/CategoricalCrypto/Ext.agda
+++ b/formal-spec/CategoricalCrypto/Ext.agda
@@ -4,10 +4,8 @@ open import Leios.Prelude hiding (id; _⊗_)
 open import CategoricalCrypto hiding (id; _∘_)
 import Relation.Binary.HeterogeneousEquality as H
 
--- | General-purpose helpers around `_≡ᴹ_` and `subst` on machines.
 module CategoricalCrypto.Ext where
 
--- Transitivity of `_≡ᴹ_`.
 ≡ᴹ-trans : ∀ {A₁ A₂ A₃ B₁ B₂ B₃}
            {M₁ : Machine A₁ B₁} {M₂ : Machine A₂ B₂} {M₃ : Machine A₃ B₃}
          → M₁ ≡ᴹ M₂ → M₂ ≡ᴹ M₃ → M₁ ≡ᴹ M₃
@@ -15,23 +13,16 @@ module CategoricalCrypto.Ext where
          record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl }
   = ≡ᴹ-refl
 
--- When both sides already have the same type, `_≡ᴹ_` collapses to `_≡_`.
 ≡ᴹ→≡ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ᴹ M₂ → M₁ ≡ M₂
 ≡ᴹ→≡ record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl } = refl
 
--- Inclusion `_≡_ → _≡ᴹ_` at matching types.
 ≡→≡ᴹ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ M₂ → M₁ ≡ᴹ M₂
 ≡→≡ᴹ refl = ≡ᴹ-refl
 
--- `subst` along a channel equality preserves the machine up to `_≡ᴹ_`
--- (variant of `subst-≡ᴹ` where the channel equation affects only the
--- output type).
 subst-≡ᴹ-out : ∀ {x y} {A : Channel} {B : Channel → Channel}
              → (eq : x ≡ y) (M : Machine A (B x))
              → subst (λ c → Machine A (B c)) eq M ≡ᴹ M
 subst-≡ᴹ-out refl _ = ≡ᴹ-refl
 
--- `idᴷ` instantiated at different (but propositionally equal) channels
--- are `_≡ᴹ_`.
 idᴷ-cong-≡ᴹ : ∀ {A B} → A ≡ B → _≡ᴹ_ (idᴷ {A = A}) (idᴷ {A = B})
 idᴷ-cong-≡ᴹ refl = ≡ᴹ-refl

--- a/formal-spec/CategoricalCrypto/Ext.agda
+++ b/formal-spec/CategoricalCrypto/Ext.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --safe #-}
+
+open import Leios.Prelude hiding (id; _⊗_)
+open import CategoricalCrypto hiding (id; _∘_)
+import Relation.Binary.HeterogeneousEquality as H
+
+-- | General-purpose helpers around `_≡ᴹ_` and `subst` on machines.
+module CategoricalCrypto.Ext where
+
+-- Transitivity of `_≡ᴹ_`.
+≡ᴹ-trans : ∀ {A₁ A₂ A₃ B₁ B₂ B₃}
+           {M₁ : Machine A₁ B₁} {M₂ : Machine A₂ B₂} {M₃ : Machine A₃ B₃}
+         → M₁ ≡ᴹ M₂ → M₂ ≡ᴹ M₃ → M₁ ≡ᴹ M₃
+≡ᴹ-trans record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl }
+         record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl }
+  = ≡ᴹ-refl
+
+-- When both sides already have the same type, `_≡ᴹ_` collapses to `_≡_`.
+≡ᴹ→≡ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ᴹ M₂ → M₁ ≡ M₂
+≡ᴹ→≡ record { A≡C = refl ; B≡D = refl ; M₁≡M₂ = H.refl } = refl
+
+-- Inclusion `_≡_ → _≡ᴹ_` at matching types.
+≡→≡ᴹ : ∀ {A B} {M₁ M₂ : Machine A B} → M₁ ≡ M₂ → M₁ ≡ᴹ M₂
+≡→≡ᴹ refl = ≡ᴹ-refl
+
+-- `subst` along a channel equality preserves the machine up to `_≡ᴹ_`
+-- (variant of `subst-≡ᴹ` where the channel equation affects only the
+-- output type).
+subst-≡ᴹ-out : ∀ {x y} {A : Channel} {B : Channel → Channel}
+             → (eq : x ≡ y) (M : Machine A (B x))
+             → subst (λ c → Machine A (B c)) eq M ≡ᴹ M
+subst-≡ᴹ-out refl _ = ≡ᴹ-refl
+
+-- `idᴷ` instantiated at different (but propositionally equal) channels
+-- are `_≡ᴹ_`.
+idᴷ-cong-≡ᴹ : ∀ {A B} → A ≡ B → _≡ᴹ_ (idᴷ {A = A}) (idᴷ {A = B})
+idᴷ-cong-≡ᴹ refl = ≡ᴹ-refl

--- a/formal-spec/Leios/Base.lagda.md
+++ b/formal-spec/Leios/Base.lagda.md
@@ -119,11 +119,16 @@ or equal than the slot of the last processed block
 
 ```agda
   open import Blockchain.Safety RankingBlock
+  import Blockchain.IsBlockchain as IsBC
   open import Data.Fin.Base using (_↑ˡ_)
 
   BaseIO = simpleChannel BaseIOF
 
   record BaseMachine : Type₂ where
+    field n : ℕ
+
+    open IsBC RankingBlock (Fin n) public
+
     field m             : Machine BaseNetwork (BaseIO ⊗₀ BaseAdv)
           is-blockchain : IsBlockchain m
 

--- a/formal-spec/Leios/Base.lagda.md
+++ b/formal-spec/Leios/Base.lagda.md
@@ -127,10 +127,10 @@ or equal than the slot of the last processed block
   record BaseMachine : Type₂ where
     field n : ℕ
 
-    open IsBC RankingBlock (Fin n) public
+    open IsBC (Fin n) public
 
     field m             : Machine BaseNetwork (BaseIO ⊗₀ BaseAdv)
-          is-blockchain : IsBlockchain m
+          is-blockchain : IsBlockchain RankingBlock m
 
     open Machine m renaming (stepRel to _-⟦_/_⟧⇀_) public
 

--- a/formal-spec/Leios/Base.lagda.md
+++ b/formal-spec/Leios/Base.lagda.md
@@ -118,7 +118,7 @@ or equal than the slot of the last processed block
 ```
 
 ```agda
-  open import Blockchain.Safety RankingBlock
+  open import Blockchain.Safety
   import Blockchain.IsBlockchain as IsBC
   open import Data.Fin.Base using (_↑ˡ_)
 

--- a/formal-spec/Leios/Base.lagda.md
+++ b/formal-spec/Leios/Base.lagda.md
@@ -133,30 +133,4 @@ or equal than the slot of the last processed block
           is-blockchain : IsBlockchain RankingBlock m
 
     open Machine m renaming (stepRel to _-⟦_/_⟧⇀_) public
-
---   module _
---     (numberOfParties     : ℕ)
---     (NAdv                : Channel)
---     (honestSpec          : BaseMachine)
---     (IOF AdvF : Fin numberOfParties → Channel)
---     (allNodes            : (p : Fin numberOfParties) → Machine BaseNetwork (IOF p ⊗ AdvF p))
---     (honestNodes         : ℙ (Fin numberOfParties))
---     (honest≡spec         : ∀ {p} → p ∈ honestNodes → allNodes p ≡ᴹ BaseMachine.m honestSpec)
---     (Net                 : Machine I (numberOfParties ⨂ⁿ BaseNetwork ⊗ NAdv))
---     (k                   : ℕ)
---     (Δ                   : ℕ)
---     (HonestStakeMajority : Type)
---     where
-
---     safetyBase : Type₁
---     safetyBase = Safety.safety
---           (BaseMachine.m honestSpec)
---           (BaseMachine.is-blockchain honestSpec)
---           IOF AdvF
---           allNodes
---           honestNodes
---           honest≡spec
---           Net
---           k
---           Δ
--- ```
+```

--- a/formal-spec/Leios/Base.lagda.md
+++ b/formal-spec/Leios/Base.lagda.md
@@ -118,7 +118,7 @@ or equal than the slot of the last processed block
 ```
 
 ```agda
-  open import Leios.Safety RankingBlock
+  open import Blockchain.Safety RankingBlock
   open import Data.Fin.Base using (_↑ˡ_)
 
   BaseIO = simpleChannel BaseIOF

--- a/formal-spec/Leios/ChannelCat.agda
+++ b/formal-spec/Leios/ChannelCat.agda
@@ -1,0 +1,110 @@
+{-# OPTIONS --safe #-}
+
+open import Leios.Prelude hiding (id; _⊗_; _∘_)
+
+open import CategoricalCrypto hiding (id)
+import CategoricalCrypto as CC
+open import Categories.Category
+open import Categories.Category.Helper
+import Categories.Morphism.Reasoning
+
+module Leios.ChannelCat where
+
+private variable A B C D E E₁ E₂ E₃ : Channel
+
+record ChannelCat : Type₁ where
+  field
+    ⊗-injectiveˡ : A ⊗₀ B ≡ C ⊗₀ D → A ≡ C
+    ⊗-injectiveʳ : A ⊗₀ B ≡ C ⊗₀ D → B ≡ D
+    ⊗-identityˡ : I ⊗₀ A ≡ A
+    ⊗-identityʳ : A ⊗₀ I ≡ A
+    I-helper : ∀ {n} → (⨂_ {n} (const I)) ≡ I
+    ∘-assoc : {M₁ : Machine C D} {M₂ : Machine B C} {M₃ : Machine A B} → (M₁ ∘ M₂) ∘ M₃ ≡ M₁ ∘ M₂ ∘ M₃
+    idᴹ : Machine A A
+    _∘ᴹ_ : Machine B C → Machine A B → Machine A C
+    ∘ᴹ-assoc : {M₃ : Machine A B} {M₂ : Machine B C} {M₁ : Machine C D}
+      → (M₁ ∘ᴹ M₂) ∘ᴹ M₃ ≡ M₁ ∘ᴹ (M₂ ∘ᴹ M₃)
+    ∘ᴹ-identityˡ : {f : Machine A B} → (idᴹ ∘ᴹ f) ≡ f
+    ∘ᴹ-identityʳ : {f : Machine A B} → (f ∘ᴹ idᴹ) ≡ f
+    ∘ᴹ-resp-≡ : {f h : Machine B C} {g i : Machine A B} → f ≡ h → g ≡ i → (f ∘ᴹ g) ≡ (h ∘ᴹ i)
+
+    assoc²γδ : {f : Machine A B} {g : Machine B C} {h : Machine C D} {i : Machine D E}
+      → (i ∘ h) ∘ (g ∘ f) ≡ i ∘ ((h ∘ g) ∘ f)
+    σ : Machine (A ⊗₀ B) (B ⊗₀ A)
+    α⇒ : Machine ((A ⊗₀ B) ⊗₀ C) (A ⊗₀ (B ⊗₀ C))
+    α⇐ : Machine (A ⊗₀ (B ⊗₀ C)) ((A ⊗₀ B) ⊗₀ C)
+    λ⇒ : Machine (I ⊗₀ A) A
+    ρ⇒ : Machine (A ⊗₀ I) A
+    ρ⇐ : Machine A (A ⊗₀ I)
+
+    ⨂ᴷ-⊗-∘ : ∀ {n} {f : Fin n → Machine B C} {g : Fin n → Machine E₁ E₂} {h : Fin n → Machine A (B ⊗₀ E₁)}
+      → ⨂ᴷ (λ k → (f k ⊗₁ g k) ∘ h k) ≡ ((⨂₁ f) ⊗₁ ⨂₁ g) ∘ ⨂ᴷ h
+
+    ∘ᴷ-assoc : {M₁ : Machine C (D ⊗₀ E₃)} {M₂ : Machine B (C ⊗₀ E₂)} {M₃ : Machine A (B ⊗₀ E₁)}
+      → (M₁ ∘ᴷ M₂) ∘ᴷ M₃ ≡ (CC.id ⊗₁ α⇒) ∘ (M₁ ∘ᴷ M₂ ∘ᴷ M₃)
+
+    ∘ᴷ-assoc' : {M₁ : Machine C (D ⊗₀ E₃)} {M₂ : Machine B (C ⊗₀ E₂)} {M₃ : Machine A (B ⊗₀ E₁)}
+      → M₁ ∘ᴷ M₂ ∘ᴷ M₃ ≡ (CC.id ⊗₁ α⇐) ∘ ((M₁ ∘ᴷ M₂) ∘ᴷ M₃)
+
+    ⨂-⊗-swap : {n : ℕ} {F₁ F₂ : Fin n → Channel} → Machine ((⨂ F₁) ⊗₀ (⨂ F₂)) (⨂ (λ k → F₁ k ⊗₀ F₂ k))
+
+    ⨂-⊗-swap' : {n : ℕ} {F₁ F₂ : Fin n → Channel} → Machine (⨂ (λ k → F₁ k ⊗₀ F₂ k)) ((⨂ F₁) ⊗₀ (⨂ F₂))
+
+    ⨂ᴷ-∘ᴷ-⨂ᴷ : ∀ {n} {f : Fin n → Machine A (B ⊗₀ E₁)} {g : Fin n → Machine B (C ⊗₀ E₂)}
+      → ⨂ᴷ (λ k → g k ∘ᴷ f k) ≡ (CC.id ⊗₁ (⨂-⊗-swap {n = n} {F₁ = const E₁} {F₂ = const E₂})) ∘ (⨂ᴷ g ∘ᴷ ⨂ᴷ f)
+
+    ⨂ᴷ-∘ᴷ-⨂ᴷ' : ∀ {n} {f : Fin n → Machine A (B ⊗₀ E₁)} {g : Fin n → Machine B (C ⊗₀ E₂)}
+      → (⨂ᴷ g ∘ᴷ ⨂ᴷ f) ≡ (CC.id ⊗₁ (⨂-⊗-swap' {n = n} {F₁ = const E₁} {F₂ = const E₂})) ∘ ⨂ᴷ (λ k → g k ∘ᴷ f k)
+
+    liftᴷ-∘ᴷ : {f : Machine A (B ⊗₀ E₁)} {g : Machine B (C ⊗₀ E₂)}
+      → liftᴷ g ∘ᴷ f ≡ ((CC.id ⊗₁ ρ⇐) ∘ α⇐ ∘ (CC.id ⊗₁ σ)) ∘ (g ∘ᴷ f)
+
+    ⨂-absorb-env-helper : ∀ {n} (D : Fin n → Channel) {E₁ E₂ : Fin n → Channel}
+      → Machine ((⨂ D ⊗₀ ⨂ E₂) ⊗₀ E ⊗₀ (⨂ E₁)) ((⨂ D) ⊗₀ E ⊗₀ (⨂ (λ k → E₁ k ⊗₀ E₂ k)))
+
+    ⨂-absorb-env : ∀ {n} {B C D E₁ E₂ : Fin n → Channel} {F : Channel}
+      (f : (k : Fin n) → Machine (C k) (D k ⊗₀ E₂ k)) (g : (k : Fin n) → Machine (B k) (C k ⊗₀ E₁ k)) (h : Machine A (⨂ B ⊗₀ E))
+      (α : Machine (⨂ D ⊗₀ E ⊗₀ ⨂ (λ k → E₁ k ⊗₀ E₂ k)) F)
+      → α ∘ (⨂ᴷ (λ k → f k ∘ᴷ g k) ∘ᴷ h) ≡ (α ∘ (⨂-absorb-env-helper D) ∘ ⨂ᴷ f ⊗₁ CC.id) ∘ (⨂ᴷ g ∘ᴷ h)
+
+    ⨂ᴷ-cong : ∀ {n} {A B E : Fin n → Channel} {f g : (k : Fin n) → Machine (A k) (B k ⊗₀ E k)}
+      → (∀ k → f k ≡ g k) → ⨂ᴷ f ≡ ⨂ᴷ g
+
+    ⨂-cong : ∀ {n} {A B : Fin n → Channel} → (∀ k → A k ≡ B k) → Machine (⨂ A) (⨂ B)
+
+  insert-id-helper : ∀ {n} (C : Fin n → Channel)
+    → Machine (A ⊗₀ B ⊗₀ (⨂ (λ k → C k ⊗₀ I))) (A ⊗₀ B ⊗₀ (⨂ C))
+  insert-id-helper {n = n} _ = CC.id ⊗₁ CC.id ⊗₁ ⨂₁ {n = n} (λ _ → ρ⇒)
+
+  field
+    insert-id : ∀ {n} {E₁} {B C E₂ : Fin n → Channel}
+      → (f : (k : Fin n) → Machine (B k) (C k ⊗₀ E₂ k)) (g : Machine A (⨂ B ⊗₀ E₁))
+      → (α : Machine (⨂ C ⊗₀ E₁ ⊗₀ ⨂ E₂) D)
+      → α ∘ (⨂ᴷ f ∘ᴷ g) ≡ (α ∘ insert-id-helper E₂) ∘ (⨂ᴷ (λ k → idᴷ ∘ᴷ f k) ∘ᴷ g)
+
+  MACHINE : Category (sucˡ zeroˡ) (sucˡ zeroˡ) (sucˡ zeroˡ)
+  MACHINE = categoryHelper record
+    { Obj = Channel
+    ; _⇒_ = Machine
+    ; _≈_ = _≡_
+    ; id = idᴹ
+    ; _∘_ = _∘ᴹ_
+    ; assoc = ∘ᴹ-assoc
+    ; identityˡ = ∘ᴹ-identityˡ
+    ; identityʳ = ∘ᴹ-identityʳ
+    ; equiv = record { refl = refl ; sym = sym ; trans = trans }
+    ; ∘-resp-≈ = ∘ᴹ-resp-≡
+    }
+
+  module M = Categories.Morphism.Reasoning MACHINE
+
+  ⊗-identityʳ-helper : B ≡ I → Machine A C → Machine (A ⊗₀ B) C
+  ⊗-identityʳ-helper {A = A} refl M = M ∘ subst (λ x → Machine x A) (sym ⊗-identityʳ) CategoricalCrypto.id
+
+  ⊗ᴷ-⊗ : {M₁ : Machine A (B ⊗₀ E₁)} {M₂ : Machine C (D ⊗₀ E₂)}
+    → ∃[ π ] M₁ ⊗ᴷ M₂ ≡ π ∘ M₁ ⊗₁ M₂
+  ⊗ᴷ-⊗ = -, refl
+
+  -- this is a structure iso
+  ⊗ᴷ-⊗₁ : Machine ((A ⊗₀ B) ⊗₀ C ⊗₀ D) ((A ⊗₀ C) ⊗₀ B ⊗₀ D)
+  ⊗ᴷ-⊗₁ = proj₁ (⊗ᴷ-⊗ {M₁ = CategoricalCrypto.id} {CategoricalCrypto.id})

--- a/formal-spec/Leios/ChannelCat.agda
+++ b/formal-spec/Leios/ChannelCat.agda
@@ -72,6 +72,12 @@ record ChannelCat : Type₁ where
 
     ⨂-cong : ∀ {n} {A B : Fin n → Channel} → (∀ k → A k ≡ B k) → Machine (⨂ A) (⨂ B)
 
+    -- Congruence of Kleisli composition under heterogeneous machine equality.
+    ∘ᴷ-cong-≡ᴹ : ∀ {A₁ A₂ B₁ B₂ C₁ C₂ E₁₁ E₁₂ E₂₁ E₂₂}
+                  {M : Machine B₁ (C₁ ⊗₀ E₂₁)} {M' : Machine B₂ (C₂ ⊗₀ E₂₂)}
+                  {N : Machine A₁ (B₁ ⊗₀ E₁₁)} {N' : Machine A₂ (B₂ ⊗₀ E₁₂)}
+                → M ≡ᴹ M' → N ≡ᴹ N' → (M ∘ᴷ N) ≡ᴹ (M' ∘ᴷ N')
+
   insert-id-helper : ∀ {n} (C : Fin n → Channel)
     → Machine (A ⊗₀ B ⊗₀ (⨂ (λ k → C k ⊗₀ I))) (A ⊗₀ B ⊗₀ (⨂ C))
   insert-id-helper {n = n} _ = CC.id ⊗₁ CC.id ⊗₁ ⨂₁ {n = n} (λ _ → ρ⇒)

--- a/formal-spec/Leios/Safety/Transfer.agda
+++ b/formal-spec/Leios/Safety/Transfer.agda
@@ -1,0 +1,180 @@
+{-# OPTIONS --safe #-}
+
+open import Leios.Prelude hiding (id; _⊗_; _∘_)
+open import Leios.Safety
+open import Leios.ChannelCat
+
+open import CategoricalCrypto hiding (id)
+import CategoricalCrypto as CC
+
+import Relation.Binary.Reasoning.PartialOrder
+open import Relation.Binary using (Poset)
+
+-- | Generic safety transfer.
+--
+-- Given an "extended" blockchain spec `ext`, a chain-projection `getBaseBlock`
+-- into a "base" blockchain spec (injective), and a honest upper layer
+-- witnessing the factoring of each honest ext node through the base spec,
+-- safety of the derived base spec implies safety of the ext spec.
+--
+-- The base-side Safety record is derived internally: honest nodes run
+-- `base-spec`, dishonest nodes inherit their original protocol from `ext`.
+module Leios.Safety.Transfer
+  {BlockExt BlockBase   : Type}
+  (getBaseBlock         : BlockExt → BlockBase)
+  (getBaseBlock-inj     : Injective _≡_ _≡_ getBaseBlock)
+  (ext                  : Safety BlockExt)
+  (cc                   : ChannelCat)
+  -- Base spec + evidence.
+  (base-IO base-Adv     : Channel)
+  (base-spec            : Machine (Safety.Network ext) (base-IO ⊗₀ base-Adv))
+  (base-IsBlockchain    : IsBlockchain BlockBase base-spec)
+  -- The ext and base adversary channels agree.  Together with
+  -- `Ext.honest-nodes-≡-spec` this lets us swap the honest ext node for
+  -- `base-spec` on the base side.
+  (ext-Adv≡base-Adv     : Safety.Adv ext ≡ base-Adv)
+  -- Honest upper layer: extends the base spec into the ext honest-node spec.
+  (ext-spec             : Machine base-IO (Safety.IO ext ⊗₀ I))
+  where
+
+module Ext = Safety ext
+open ChannelCat cc
+
+-- On honest nodes, the per-participant channels agree with the ext spec's
+-- `IO`/`Adv` channels.  Derived from `Ext.honest-nodes-≡-spec`.
+honest-IOF : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → Ext.IOF p ≡ Ext.IO
+honest-IOF hp = ⊗-injectiveˡ (_≡ᴹ_.B≡D (Ext.honest-nodes-≡-spec hp))
+
+honest-AdvF : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → Ext.AdvF p ≡ base-Adv
+honest-AdvF hp = trans (⊗-injectiveʳ (_≡ᴹ_.B≡D (Ext.honest-nodes-≡-spec hp))) ext-Adv≡base-Adv
+
+-- Per-participant base IO channel: `base-IO` on honest nodes, else ext IOF.
+base-IOF : Fin Ext.n → Channel
+base-IOF p = case p ∈? Ext.honest-nodes of λ where
+  (yes _) → base-IO
+  (no  _) → Ext.IOF p
+
+-- Honest nodes are replaced by `base-spec`; dishonest nodes are unchanged.
+base-all-nodes : (p : Fin Ext.n) → Machine Ext.Network (base-IOF p ⊗₀ Ext.AdvF p)
+base-all-nodes p with p ∈? Ext.honest-nodes
+... | yes hp = subst (λ x → Machine Ext.Network (base-IO ⊗₀ x)) (sym (honest-AdvF hp)) base-spec
+... | no  _  = Ext.all-nodes p
+
+private
+  subst-≡ᴹ : ∀ {x y : Channel} {A B : Channel → Channel} → (eq : x ≡ y)
+    → (M : Machine (A x) (B x)) → subst (λ x → Machine (A x) (B x)) eq M ≡ᴹ M
+  subst-≡ᴹ refl _ = ≡ᴹ-refl
+
+base-honest-≡-spec : {p : Fin Ext.n} → p ∈ Ext.honest-nodes → base-all-nodes p ≡ᴹ base-spec
+base-honest-≡-spec {p} hp with p ∈? Ext.honest-nodes
+... | yes hp' = subst-≡ᴹ (sym (honest-AdvF hp')) base-spec
+... | no ¬hp  = contradiction hp ¬hp
+
+-- Derived per-participant extension piece: honest nodes get `ext-spec`
+-- (transported from `Ext.IO` to `Ext.IOF p`), dishonest nodes get identity
+-- (with `base-IOF p` definitionally `Ext.IOF p`).
+extPart : (p : Fin Ext.n) → Machine (base-IOF p) (Ext.IOF p ⊗₀ I)
+extPart p with p ∈? Ext.honest-nodes
+... | yes hp = subst (λ x → Machine base-IO (x ⊗₀ I)) (sym (honest-IOF hp)) ext-spec
+... | no  _  = idᴷ
+
+-- The derived base Safety record.
+base : Safety BlockBase
+base = record
+  { n                   = Ext.n
+  ; IO                  = base-IO
+  ; Adv                 = base-Adv
+  ; NAdv                = Ext.NAdv
+  ; Network             = Ext.Network
+  ; honest-node-spec    = base-spec
+  ; spec-IsBlockchain   = base-IsBlockchain
+  ; IOF                 = base-IOF
+  ; AdvF                = Ext.AdvF
+  ; all-nodes           = base-all-nodes
+  ; honest-nodes        = Ext.honest-nodes
+  ; honest-nodes-≡-spec = base-honest-≡-spec
+  ; network             = Ext.network
+  }
+
+module Base = Safety base
+
+-- The remaining transfer requires the caller to prove that every ext node
+-- factors as `extPart p ∘ᴷ base-all-nodes p`.  Since `extPart` is derived
+-- above, this proof is stated in terms of the derived definition.
+module Main (single-protocol-≡ : ∀ p
+                               → idᴷ ∘ᴷ Ext.all-nodes p
+                               ≡ extPart p ∘ᴷ base-all-nodes p) where
+
+  -- | Translation from extended protocols to base protocols.
+  module _ {A : Channel} (E : Ext.Environment A) where
+
+    -- this is a structure isomorphism
+    transId : Machine
+      ((⨂ Ext.IOF ⊗₀ (⨂_ {n = Ext.n} (const I))) ⊗₀ (Ext.NAdv ⊗₀ ⨂ Ext.AdvF))
+      (⨂ Ext.IOF ⊗₀ (Ext.NAdv ⊗₀ ⨂ Ext.AdvF))
+    transId = insert-id-helper Ext.AdvF ∘ (⨂-absorb-env-helper Ext.IOF)
+
+    -- This is `E`, but we absorb the `extPart` part of each participant.
+    transEnv : Base.Environment A
+    transEnv = E ∘ transId ∘ ⨂ᴷ extPart ⊗₁ CC.id
+
+    transProtocol : Ext.protocol E ≡ᴹ Base.protocol transEnv
+    transProtocol = flip (subst (Ext.protocol E ≡ᴹ_)) ≡ᴹ-refl $
+      E ∘ (Ext.nodes ∘ᴷ Ext.network) ≡⟨ insert-id Ext.all-nodes Ext.network E ⟩
+      (E ∘ insert-id-helper Ext.AdvF) ∘ (⨂ᴷ (λ p → idᴷ ∘ᴷ Ext.all-nodes p) ∘ᴷ Ext.network)
+        ≡⟨ cong (λ x → (E ∘ insert-id-helper Ext.AdvF) ∘ x ∘ᴷ Ext.network) (⨂ᴷ-cong single-protocol-≡) ⟩
+      (E ∘ insert-id-helper Ext.AdvF) ∘ (⨂ᴷ (λ p → extPart p ∘ᴷ base-all-nodes p) ∘ᴷ Ext.network)
+        ≡⟨ ⨂-absorb-env extPart base-all-nodes Ext.network (E ∘ insert-id-helper Ext.AdvF) ⟩
+      ((E ∘ insert-id-helper Ext.AdvF) ∘ (⨂-absorb-env-helper Ext.IOF) ∘ ⨂ᴷ extPart ⊗₁ CC.id) ∘ ((⨂ᴷ base-all-nodes) ∘ᴷ Ext.network)
+        ≡⟨ cong (_∘ (Base.nodes ∘ᴷ Ext.network)) (assoc²γδ {g = ⨂-absorb-env-helper Ext.IOF} {h = insert-id-helper Ext.AdvF}) ⟩
+      (E ∘ transId ∘ ⨂ᴷ extPart ⊗₁ CC.id) ∘ (Base.nodes ∘ᴷ Base.network) ∎
+      where
+        open ≡-Reasoning
+
+    transState : Machine.State (Ext.protocol E) → Machine.State (Base.protocol transEnv)
+    transState = state-subst transProtocol
+
+    transTrace : {s₁ s₂ : Machine.State (Ext.protocol E)} → Trace (Ext.protocol E) s₁ s₂
+      → Trace (Base.protocol transEnv) (transState s₁) (transState s₂)
+    transTrace = Trace-subst transProtocol
+
+  -- | Chain lemma: the base chain is the `getBaseBlock`-projection of the ext chain.
+  ChainLemma-ty : ∀ {A : Channel} → Ext.Environment A → Type
+  ChainLemma-ty {A} E = ∀ {p : Fin Ext.n} {s} (p-honest : p ∈ Ext.honest-nodes)
+    → Base.getChain (transEnv E) (transState E s) p-honest
+    ≡ map getBaseBlock (Ext.getChain E s p-honest)
+
+  module ≼-Reasoning {A} = Relation.Binary.Reasoning.PartialOrder (Poset-≼ {A})
+
+  module _ {A : Channel} (E : Ext.Environment A) (CL : ChainLemma-ty E) (s : Machine.State (Ext.protocol E)) where
+    open ≼-Reasoning
+
+    private
+      inj-≼ : {l₁ l₂ : List BlockExt}
+            → map getBaseBlock l₁ ≼ map getBaseBlock l₂ → l₁ ≼ l₂
+      inj-≼ = inj-map-≼ getBaseBlock-inj
+
+    safeState-ext⇒base : (k : ℕ) → Ext.safeState k E s → Base.safeState k (transEnv E) (transState E s)
+    safeState-ext⇒base k safe hp hp' = begin
+        prune k (Base.getChain (transEnv E) (transState E s) hp)   ≡⟨ cong (prune k) (CL hp) ⟩
+        prune k (map getBaseBlock (Ext.getChain E s hp))           ≡⟨ prune-map {k = k} ⟩
+        map getBaseBlock (prune k (Ext.getChain E s hp))           ≤⟨ map-≼ (safe hp hp') ⟩
+        map getBaseBlock (Ext.getChain E s hp')                    ≡⟨ CL hp' ⟨
+        Base.getChain (transEnv E) (transState E s) hp'            ∎
+
+    safeState-base⇒ext : (k : ℕ) → Base.safeState k (transEnv E) (transState E s) → Ext.safeState k E s
+    safeState-base⇒ext k safe hp hp' = inj-≼ $ begin
+        map getBaseBlock (prune k (Ext.getChain E s hp))           ≡⟨ prune-map {k = k} ⟨
+        prune k (map getBaseBlock (Ext.getChain E s hp))           ≡⟨ cong (prune k) (CL hp) ⟨
+        prune k (Base.getChain (transEnv E) (transState E s) hp)   ≤⟨ safe hp hp' ⟩
+        Base.getChain (transEnv E) (transState E s) hp'            ≡⟨ CL hp' ⟩
+        map getBaseBlock (Ext.getChain E s hp')                    ∎
+
+  transfer : (k : ℕ)
+           → (∀ {A} (E : Ext.Environment A) → ChainLemma-ty E)
+           → Base.safety k → Ext.safety k
+  transfer k CL baseSafety E init final trace safeInit =
+    safeState-base⇒ext E (CL E) final k
+      (baseSafety (transEnv E) (transState E init) (transState E final)
+                  (transTrace E trace)
+                  (safeState-ext⇒base E (CL E) init k safeInit))

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -10,8 +10,10 @@ open import CategoricalCrypto.Channel.Selection
 import CategoricalCrypto as CC
 
 open import Blockchain.Safety
+open import Blockchain.Liveness as BLiveness using (Liveness)
 open import Leios.ChannelCat
 import Blockchain.Safety.Transfer as Transfer
+import Blockchain.Liveness.Transfer as LTransfer
 
 module Network.Leios
   (⋯ : SpecStructure) (let open SpecStructure ⋯)
@@ -133,6 +135,15 @@ module _ (IOF AdvF : Participant → Channel)
         ⊗-identityʳ
         ext-spec
 
+      module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+        LeiosBlock.rb LeiosBlock-Injective
+        safetyS
+        cc
+        (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
+        spec IsBlockchain-spec
+        ⊗-identityʳ
+        ext-spec
+
     single-protocol-≡-ty : Type₁
     single-protocol-≡-ty = ∀ p → idᴷ ∘ᴷ S.all-nodes p ≡ Tr.extPart p ∘ᴷ Tr.base-all-nodes p
 
@@ -142,3 +153,26 @@ module _ (IOF AdvF : Participant → Channel)
       leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
                   → Safety.safety Tr.base k → Safety.safety safetyS k
       leiosSafety = TrM.transfer k
+
+      -- Liveness transfer: given a Liveness record for the base (ranking-block)
+      -- spec, we derive a Liveness record for the full Leios spec by pulling
+      -- back `producer` and `slotOf` along `LeiosBlock.rb`, and transfer HCG
+      -- and ∃CQ from base to ext.
+      module _ (baseLiv : LTr.BL.Liveness) where
+
+        private module LTrM = LTr.Main baseLiv single-protocol-≡
+
+        leiosLiveness : LTr.EL.Liveness
+        leiosLiveness = LTr.extLiv baseLiv
+
+        leiosHCG : (∀ {A} (E : Safety.Environment safetyS A) → LTrM.TrM.ChainLemma-ty E)
+                 → (∀ {A} (E : Safety.Environment safetyS A) → LTrM.SlotLemma-ty E)
+                 → ∀ τ → BLiveness.Liveness.hcg RankingBlock Tr.base baseLiv τ
+                       → BLiveness.Liveness.hcg LeiosBlock safetyS leiosLiveness τ
+        leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
+
+        leios∃CQ : (∀ {A} (E : Safety.Environment safetyS A) → LTrM.TrM.ChainLemma-ty E)
+                 → (∀ {A} (E : Safety.Environment safetyS A) → LTrM.SlotLemma-ty E)
+                 → ∀ T → BLiveness.Liveness.∃cq RankingBlock Tr.base baseLiv T
+                       → BLiveness.Liveness.∃cq LeiosBlock safetyS leiosLiveness T
+        leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -125,28 +125,26 @@ module _ (IOF AdvF : Participant → Channel)
     ; slotOf        = λ b → IBB.slotOf   (LeiosBlock.rb b)
     }
 
-  safetyS : Safety LeiosBlock
+  safetyS : Deployment LeiosBlock
   safetyS = record
-    { n          = numberOfParties
-    ; Network    = _
-    ; spec       = record
+    { n                   = numberOfParties
+    ; Network             = _
+    ; spec                = record
         { IO                = _
         ; Adv               = _
         ; honest-node-spec  = Leios1
         ; spec-IsBlockchain = IsBlockchain-Leios
         }
-    ; deployment = record
-        { NAdv                = _
-        ; IOF                 = IOF
-        ; AdvF                = AdvF
-        ; all-nodes           = nodesF
-        ; honest-nodes        = honestNodes
-        ; honest-nodes-≡-spec = honest-Node
-        ; network             = DD.Network
-        }
+    ; NAdv                = _
+    ; IOF                 = IOF
+    ; AdvF                = AdvF
+    ; all-nodes           = nodesF
+    ; honest-nodes        = honestNodes
+    ; honest-nodes-≡-spec = honest-Node
+    ; network             = DD.Network
     }
 
-  module S = Safety safetyS
+  module S = Deployment safetyS
 
   base-spec : Spec RankingBlock S.n S.Network
   base-spec = record
@@ -156,7 +154,7 @@ module _ (IOF AdvF : Participant → Channel)
     ; spec-IsBlockchain = IsBlockchain-base
     }
 
-  extension : IsExtension base-spec (Safety.spec safetyS)
+  extension : IsExtension base-spec (Deployment.spec safetyS)
   extension = record
     { ext-Adv≡base-Adv = ⊗-identityʳ
     ; ext-layer        = ext-spec
@@ -170,8 +168,8 @@ module _ (IOF AdvF : Participant → Channel)
       safetyS base-spec cc extension
     module TrM = Tr.Main
 
-  leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
-              → Safety.safety Tr.base k → S.safety k
+  leiosSafety : (∀ {A} (E : Deployment.Environment safetyS A) → TrM.ChainLemma-ty E)
+              → Deployment.safety Tr.base k → S.safety k
   leiosSafety = TrM.transfer k
 
   private

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -108,11 +108,23 @@ ext-spec = subst (λ x → Machine (Network ⊗₀ BaseIO) (IO ⊗₀ x)) eq bod
 module _ (IOF AdvF : Participant → Channel)
   (nodesF : (p : Participant) → Machine DD.M (IOF p ⊗₀ AdvF p)) honestNodes
   (honest-Node : {p : Participant} → p ∈ honestNodes → nodesF p ≡ᴹ Leios1)
-  (IsBlockchain-Leios : IsBC.IsBlockchain Participant LeiosBlock Leios1)
+  (isConstrained-Leios : IsConstrained Leios1 (IsBC.bciQueryType Participant {Block = LeiosBlock}))
+  (isPure-Leios        : IsPure isConstrained-Leios)
   (IsBlockchain-base : IsBC.IsBlockchain Participant RankingBlock spec)
   (is-extension-eq :
     idᴷ ∘ᴷ Leios1 ≡ subst (λ A → Machine DD.M (IO ⊗₀ (A ⊗₀ I))) (sym ⊗-identityʳ) (ext-spec ∘ᴷ spec))
     where
+
+  private
+    module IBB = IsBC.IsBlockchain IsBlockchain-base
+
+  IsBlockchain-Leios : IsBC.IsBlockchain Participant LeiosBlock Leios1
+  IsBlockchain-Leios = record
+    { isConstrained = isConstrained-Leios
+    ; isPure        = isPure-Leios
+    ; producer      = λ b → IBB.producer (LeiosBlock.rb b)
+    ; slotOf        = λ b → IBB.slotOf   (LeiosBlock.rb b)
+    }
 
   safetyS : Safety LeiosBlock
   safetyS = record
@@ -163,27 +175,17 @@ module _ (IOF AdvF : Participant → Channel)
               → Safety.safety Tr.base k → S.safety k
   leiosSafety = TrM.transfer k
 
-  -- Liveness transfer additionally requires the two block-level
-  -- compatibility witnesses.
-  module _ (producer-compat : ∀ b → S.producer b
-                                  ≡ Spec.producer base-spec
-                                      (IsExtension.getBaseBlock extension b))
-           (slotOf-compat   : ∀ b → S.slotOf b
-                                  ≡ Spec.slotOf base-spec
-                                      (IsExtension.getBaseBlock extension b))
-    where
+  private
+    module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+      safetyS base-spec cc extension (λ _ → refl) (λ _ → refl)
+    module LTrM = LTr.Main
 
-    private
-      module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-        safetyS base-spec cc extension producer-compat slotOf-compat
-      module LTrM = LTr.Main
+  leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+           → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+           → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
+  leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
 
-    leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-             → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-             → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
-    leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
-
-    leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-             → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-             → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
-    leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL
+  leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+           → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+           → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
+  leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -7,13 +7,14 @@ open import Leios.Config
 
 open import CategoricalCrypto hiding (id)
 open import CategoricalCrypto.Channel.Selection
-import CategoricalCrypto as CC
 
 open import Blockchain.Safety
 import Blockchain.IsBlockchain as IsBC
 open import Leios.ChannelCat
 import Blockchain.Safety.Transfer as Transfer
 import Blockchain.Liveness.Transfer as LTransfer
+
+open import Data.Product.Properties
 
 module Network.Leios
   (⋯ : SpecStructure) (let open SpecStructure ⋯)
@@ -79,8 +80,6 @@ record LeiosBlock : Type where
   field rb : RankingBlock
         eb : Maybe EndorserBlock
         correct : HashCorrectB rb eb
-
-open import Data.Product.Properties
 
 hash-unique' : (rb : RankingBlock) → (eb₁ eb₂ : Maybe EndorserBlock)
   → (hc₁ : HashCorrectB rb eb₁) → (hc₂ : HashCorrectB rb eb₂) → (eb₁ , hc₁) ≡ (eb₂ , hc₂)

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -151,13 +151,9 @@ module _ (IOF AdvF : Participant → Channel)
       private module TrM = Tr.Main single-protocol-≡
 
       leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
-                  → Safety.safety Tr.base k → Safety.safety safetyS k
+                  → Safety.safety Tr.base k → S.safety k
       leiosSafety = TrM.transfer k
 
-      -- Liveness transfer: given a Liveness record for the base (ranking-block)
-      -- spec, we derive a Liveness record for the full Leios spec by pulling
-      -- back `producer` and `slotOf` along `LeiosBlock.rb`, and transfer HCG
-      -- and ∃CQ from base to ext.
       module _ (baseLiv : LTr.BL.Liveness) where
 
         private module LTrM = LTr.Main baseLiv single-protocol-≡
@@ -165,14 +161,14 @@ module _ (IOF AdvF : Participant → Channel)
         leiosLiveness : LTr.EL.Liveness
         leiosLiveness = LTr.extLiv baseLiv
 
-        leiosHCG : (∀ {A} (E : Safety.Environment safetyS A) → LTrM.TrM.ChainLemma-ty E)
-                 → (∀ {A} (E : Safety.Environment safetyS A) → LTrM.SlotLemma-ty E)
+        leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
                  → ∀ τ → LTr.BL.Liveness.hcg baseLiv τ
                        → LTr.EL.Liveness.hcg leiosLiveness τ
         leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
 
-        leios∃CQ : (∀ {A} (E : Safety.Environment safetyS A) → LTrM.TrM.ChainLemma-ty E)
-                 → (∀ {A} (E : Safety.Environment safetyS A) → LTrM.SlotLemma-ty E)
+        leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
                  → ∀ T → LTr.BL.Liveness.∃cq baseLiv T
                        → LTr.EL.Liveness.∃cq leiosLiveness T
         leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -99,18 +99,26 @@ module _ (IOF AdvF : Participant → Channel)
   (IsBlockchain-Leios : IsBC.IsBlockchain Participant LeiosBlock Leios1)
   where
 
-  module LS {Block : Type}
-    (IsBlockchain-Block : IsBC.IsBlockchain Participant Block Leios1) where
-    n = numberOfParties
-    honest-node-spec = Leios1
-    spec-IsBlockchain = IsBlockchain-Block
-    all-nodes = nodesF
-    honest-nodes = honestNodes
-    network = DD.Network
-    honest-nodes-≡-spec = honest-Node
-
   safetyS : Safety LeiosBlock
-  safetyS = record { LS IsBlockchain-Leios }
+  safetyS = record
+    { n          = numberOfParties
+    ; Network    = _
+    ; spec       = record
+        { IO                = _
+        ; Adv               = _
+        ; honest-node-spec  = Leios1
+        ; spec-IsBlockchain = IsBlockchain-Leios
+        }
+    ; deployment = record
+        { NAdv                = _
+        ; IOF                 = IOF
+        ; AdvF                = AdvF
+        ; all-nodes           = nodesF
+        ; honest-nodes        = honestNodes
+        ; honest-nodes-≡-spec = honest-Node
+        ; network             = DD.Network
+        }
+    }
 
   module S = Safety safetyS
 
@@ -125,22 +133,11 @@ module _ (IOF AdvF : Participant → Channel)
       body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
       body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
 
-  module _ (IsBlockchain-spec : IsBC.IsBlockchain Participant RankingBlock spec)
-           (compat : IsBC.IsBlockchain-compatible
-                       Participant IsBlockchain-spec (Safety.spec-IsBlockchain safetyS))
-           where
-
-    open IsBC.IsBlockchain-compatible compat
+  module _ (extension : IsExtension {RankingBlock} (Safety.spec safetyS)) where
 
     private
       module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-        getBaseBlock getBaseBlock-inj
-        safetyS
-        cc
-        (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
-        spec IsBlockchain-spec
-        ⊗-identityʳ
-        ext-spec
+        safetyS cc extension
 
     single-protocol-≡-ty : Type₁
     single-protocol-≡-ty = ∀ p → idᴷ ∘ᴷ S.all-nodes p ≡ Tr.extPart p ∘ᴷ Tr.base-all-nodes p
@@ -152,24 +149,30 @@ module _ (IOF AdvF : Participant → Channel)
                   → Safety.safety Tr.base k → S.safety k
       leiosSafety = TrM.transfer k
 
-      private
-        module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-          safetyS
-          cc
-          (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
-          spec IsBlockchain-spec
-          compat
-          ⊗-identityʳ
-          ext-spec
+      -- Liveness transfer additionally requires the two block-level
+      -- compatibility witnesses.
+      module _ (producer-compat : ∀ b → S.producer b
+                                      ≡ IsBC.IsBlockchain.producer
+                                          (IsExtension.base-IsBlockchain extension)
+                                          (IsExtension.getBaseBlock extension b))
+               (slotOf-compat   : ∀ b → S.slotOf b
+                                      ≡ IsBC.IsBlockchain.slotOf
+                                          (IsExtension.base-IsBlockchain extension)
+                                          (IsExtension.getBaseBlock extension b))
+        where
 
-        module LTrM = LTr.Main single-protocol-≡
+        private
+          module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+            safetyS cc extension producer-compat slotOf-compat
 
-      leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-               → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
-      leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
+          module LTrM = LTr.Main single-protocol-≡
 
-      leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-               → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
-      leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL
+        leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+                 → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
+        leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
+
+        leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+                 → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
+        leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -96,11 +96,11 @@ module _ (IOF AdvF : Participant → Channel)
   (nodesF : (p : Participant) → Machine DD.M (IOF p ⊗₀ AdvF p)) honestNodes
   (honest-Node : {p : Participant} → p ∈ honestNodes → nodesF p ≡ᴹ Leios1)
   (cc : ChannelCat) (let open ChannelCat cc)
-  (IsBlockchain-Leios : Blockchain.IsBlockchain.IsBlockchain LeiosBlock Participant Leios1)
+  (IsBlockchain-Leios : Blockchain.IsBlockchain.IsBlockchain Participant LeiosBlock Leios1)
   where
 
   module LS {Block : Type}
-    (Leios-IsBlockchain : Blockchain.IsBlockchain.IsBlockchain Block Participant Leios1) where
+    (Leios-IsBlockchain : Blockchain.IsBlockchain.IsBlockchain Participant Block Leios1) where
     n = numberOfParties
     honest-node-spec = Leios1
     spec-IsBlockchain = Leios-IsBlockchain
@@ -125,13 +125,16 @@ module _ (IOF AdvF : Participant → Channel)
       body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
       body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
 
-  module _ (IsBlockchain-spec : Blockchain.IsBlockchain.IsBlockchain RankingBlock Participant spec) where
+  module _ (IsBlockchain-spec : Blockchain.IsBlockchain.IsBlockchain Participant RankingBlock spec)
+           (compat : Blockchain.IsBlockchain.IsBlockchain-compatible
+                       Participant IsBlockchain-spec (Safety.spec-IsBlockchain safetyS))
+           where
 
-    open Blockchain.IsBlockchain RankingBlock Participant using () renaming (IsBlockchain to IsBlockchain-RB)
+    open Blockchain.IsBlockchain.IsBlockchain-compatible compat
 
     private
       module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-        LeiosBlock.rb LeiosBlock-Injective
+        getBaseBlock getBaseBlock-inj
         safetyS
         cc
         (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
@@ -149,33 +152,24 @@ module _ (IOF AdvF : Participant → Channel)
                   → Safety.safety Tr.base k → S.safety k
       leiosSafety = TrM.transfer k
 
-      -- Liveness transfer: provided the block-level metadata of the ext spec
-      -- factors through `LeiosBlock.rb`, HCG and ∃CQ transfer from base to ext.
-      module _ (producer-compat : ∀ b → S.producer b
-                                      ≡ IsBlockchain-RB.producer IsBlockchain-spec (LeiosBlock.rb b))
-               (slotOf-compat   : ∀ b → S.slotOf b
-                                      ≡ IsBlockchain-RB.slotOf IsBlockchain-spec (LeiosBlock.rb b))
-        where
+      private
+        module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+          safetyS
+          cc
+          (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
+          spec IsBlockchain-spec
+          compat
+          ⊗-identityʳ
+          ext-spec
 
-        private
-          module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-            LeiosBlock.rb LeiosBlock-Injective
-            safetyS
-            cc
-            (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
-            spec IsBlockchain-spec
-            ⊗-identityʳ
-            ext-spec
-            producer-compat slotOf-compat
+        module LTrM = LTr.Main single-protocol-≡
 
-          module LTrM = LTr.Main single-protocol-≡
+      leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+               → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
+      leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
 
-        leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-                 → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
-        leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
-
-        leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-                 → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
-        leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL
+      leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+               → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
+      leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -1,7 +1,6 @@
 {-# OPTIONS --safe #-}
 
 open import Leios.Prelude hiding (id; _⊗_; _∘_; All)
-import Leios.Prelude as PL
 open import Leios.FFD
 open import Leios.SpecStructure
 open import Leios.Config
@@ -9,11 +8,10 @@ open import Leios.Config
 open import CategoricalCrypto hiding (id)
 open import CategoricalCrypto.Channel.Selection
 import CategoricalCrypto as CC
-open import Categories.Category
-open import Categories.Category.Helper
-import Categories.Morphism.Reasoning
 
 open import Leios.Safety
+open import Leios.ChannelCat
+import Leios.Safety.Transfer as Transfer
 
 module Network.Leios
   (⋯ : SpecStructure) (let open SpecStructure ⋯)
@@ -29,11 +27,6 @@ open Types params hiding (Network)
 
 open import Leios.NetworkShim ⋯ params
 open BaseAbstract B'
-
-import Relation.Binary.Reasoning.PartialOrder
-open import Relation.Binary using (Poset)
-
-module ≼-Reasoning {A} = Relation.Binary.Reasoning.PartialOrder (Poset-≼ {A})
 
 LeiosMsg = FFDA.Header ⊎ FFDA.Body
 Message  = LeiosMsg ⊎ BaseMsg
@@ -97,105 +90,6 @@ LeiosBlock-Injective
   subst (λ (eb , correct) → _ ≡ record { rb = rb ; eb = eb ; correct = correct })
     (hash-unique' rb eb₁ eb₂ correct₁ correct₂) refl
 
-private variable A B C D E E₁ E₂ E₃ : Channel
-
-record ChannelCat : Type₁ where
-  field
-    ⊗-injectiveˡ : A ⊗₀ B ≡ C ⊗₀ D → A ≡ C
-    ⊗-injectiveʳ : A ⊗₀ B ≡ C ⊗₀ D → B ≡ D
-    ⊗-identityˡ : I ⊗₀ A ≡ A
-    ⊗-identityʳ : A ⊗₀ I ≡ A
-    I-helper : ∀ {n} → (⨂_ {n} (const I)) ≡ I
-    ∘-assoc : {M₁ : Machine C D} {M₂ : Machine B C} {M₃ : Machine A B} → (M₁ ∘ M₂) ∘ M₃ ≡ M₁ ∘ M₂ ∘ M₃
-    idᴹ : Machine A A
-    _∘ᴹ_ : Machine B C → Machine A B → Machine A C
-    ∘ᴹ-assoc : {M₃ : Machine A B} {M₂ : Machine B C} {M₁ : Machine C D}
-      → (M₁ ∘ᴹ M₂) ∘ᴹ M₃ ≡ M₁ ∘ᴹ (M₂ ∘ᴹ M₃)
-    ∘ᴹ-identityˡ : {f : Machine A B} → (idᴹ ∘ᴹ f) ≡ f
-    ∘ᴹ-identityʳ : {f : Machine A B} → (f ∘ᴹ idᴹ) ≡ f
-    ∘ᴹ-resp-≡ : {f h : Machine B C} {g i : Machine A B} → f ≡ h → g ≡ i → (f ∘ᴹ g) ≡ (h ∘ᴹ i)
-
-    assoc²γδ : {f : Machine A B} {g : Machine B C} {h : Machine C D} {i : Machine D E}
-      → (i ∘ h) ∘ (g ∘ f) ≡ i ∘ ((h ∘ g) ∘ f)
-    σ : Machine (A ⊗₀ B) (B ⊗₀ A)
-    α⇒ : Machine ((A ⊗₀ B) ⊗₀ C) (A ⊗₀ (B ⊗₀ C))
-    α⇐ : Machine (A ⊗₀ (B ⊗₀ C)) ((A ⊗₀ B) ⊗₀ C)
-    λ⇒ : Machine (I ⊗₀ A) A
-    ρ⇒ : Machine (A ⊗₀ I) A
-    ρ⇐ : Machine A (A ⊗₀ I)
-
-    ⨂ᴷ-⊗-∘ : ∀ {n} {f : Fin n → Machine B C} {g : Fin n → Machine E₁ E₂} {h : Fin n → Machine A (B ⊗₀ E₁)}
-      → ⨂ᴷ (λ k → (f k ⊗₁ g k) ∘ h k) ≡ ((⨂₁ f) ⊗₁ ⨂₁ g) ∘ ⨂ᴷ h
-
-    ∘ᴷ-assoc : {M₁ : Machine C (D ⊗₀ E₃)} {M₂ : Machine B (C ⊗₀ E₂)} {M₃ : Machine A (B ⊗₀ E₁)}
-      → (M₁ ∘ᴷ M₂) ∘ᴷ M₃ ≡ (CC.id ⊗₁ α⇒) ∘ (M₁ ∘ᴷ M₂ ∘ᴷ M₃)
-
-    ∘ᴷ-assoc' : {M₁ : Machine C (D ⊗₀ E₃)} {M₂ : Machine B (C ⊗₀ E₂)} {M₃ : Machine A (B ⊗₀ E₁)}
-      → M₁ ∘ᴷ M₂ ∘ᴷ M₃ ≡ (CC.id ⊗₁ α⇐) ∘ ((M₁ ∘ᴷ M₂) ∘ᴷ M₃)
-
-    ⨂-⊗-swap : {n : ℕ} {F₁ F₂ : Fin n → Channel} → Machine ((⨂ F₁) ⊗₀ (⨂ F₂)) (⨂ (λ k → F₁ k ⊗₀ F₂ k))
-
-    ⨂-⊗-swap' : {n : ℕ} {F₁ F₂ : Fin n → Channel} → Machine (⨂ (λ k → F₁ k ⊗₀ F₂ k)) ((⨂ F₁) ⊗₀ (⨂ F₂))
-
-    ⨂ᴷ-∘ᴷ-⨂ᴷ : ∀ {n} {f : Fin n → Machine A (B ⊗₀ E₁)} {g : Fin n → Machine B (C ⊗₀ E₂)}
-      → ⨂ᴷ (λ k → g k ∘ᴷ f k) ≡ (CC.id ⊗₁ (⨂-⊗-swap {n = n} {F₁ = const E₁} {F₂ = const E₂})) ∘ (⨂ᴷ g ∘ᴷ ⨂ᴷ f)
-
-    ⨂ᴷ-∘ᴷ-⨂ᴷ' : ∀ {n} {f : Fin n → Machine A (B ⊗₀ E₁)} {g : Fin n → Machine B (C ⊗₀ E₂)}
-      → (⨂ᴷ g ∘ᴷ ⨂ᴷ f) ≡ (CC.id ⊗₁ (⨂-⊗-swap' {n = n} {F₁ = const E₁} {F₂ = const E₂})) ∘ ⨂ᴷ (λ k → g k ∘ᴷ f k)
-
-    liftᴷ-∘ᴷ : {f : Machine A (B ⊗₀ E₁)} {g : Machine B (C ⊗₀ E₂)}
-      → liftᴷ g ∘ᴷ f ≡ ((CC.id ⊗₁ ρ⇐) ∘ α⇐ ∘ (CC.id ⊗₁ σ)) ∘ (g ∘ᴷ f)
-
-    ⨂-absorb-env-helper : ∀ {n} (D : Fin n → Channel) {E₁ E₂ : Fin n → Channel}
-      → Machine ((⨂ D ⊗₀ ⨂ E₂) ⊗₀ E ⊗₀ (⨂ E₁)) ((⨂ D) ⊗₀ E ⊗₀ (⨂ (λ k → E₁ k ⊗₀ E₂ k)))
-
-    ⨂-absorb-env : ∀ {n} {B C D E₁ E₂ : Fin n → Channel} {F : Channel}
-      (f : (k : Fin n) → Machine (C k) (D k ⊗₀ E₂ k)) (g : (k : Fin n) → Machine (B k) (C k ⊗₀ E₁ k)) (h : Machine A (⨂ B ⊗₀ E))
-      (α : Machine (⨂ D ⊗₀ E ⊗₀ ⨂ (λ k → E₁ k ⊗₀ E₂ k)) F)
-      → α ∘ (⨂ᴷ (λ k → f k ∘ᴷ g k) ∘ᴷ h) ≡ (α ∘ (⨂-absorb-env-helper D) ∘ ⨂ᴷ f ⊗₁ CC.id) ∘ (⨂ᴷ g ∘ᴷ h)
-
-    ⨂ᴷ-cong : ∀ {n} {A B E : Fin n → Channel} {f g : (k : Fin n) → Machine (A k) (B k ⊗₀ E k)}
-      → (∀ k → f k ≡ g k) → ⨂ᴷ f ≡ ⨂ᴷ g
-
-    ⨂-cong : ∀ {n} {A B : Fin n → Channel} → (∀ k → A k ≡ B k) → Machine (⨂ A) (⨂ B)
-
-  insert-id-helper : ∀ {n} (C : Fin n → Channel)
-    → Machine (A ⊗₀ B ⊗₀ (⨂ (λ k → C k ⊗₀ I))) (A ⊗₀ B ⊗₀ (⨂ C))
-  insert-id-helper {n = n} _ = CC.id ⊗₁ CC.id ⊗₁ ⨂₁ {n = n} (λ _ → ρ⇒)
-
-  field
-    insert-id : ∀ {n} {E₁} {B C E₂ : Fin n → Channel}
-      → (f : (k : Fin n) → Machine (B k) (C k ⊗₀ E₂ k)) (g : Machine A (⨂ B ⊗₀ E₁))
-      → (α : Machine (⨂ C ⊗₀ E₁ ⊗₀ ⨂ E₂) D)
-      → α ∘ (⨂ᴷ f ∘ᴷ g) ≡ (α ∘ insert-id-helper E₂) ∘ (⨂ᴷ (λ k → idᴷ ∘ᴷ f k) ∘ᴷ g)
-
-  MACHINE : Category (sucˡ zeroˡ) (sucˡ zeroˡ) (sucˡ zeroˡ)
-  MACHINE = categoryHelper record
-    { Obj = Channel
-    ; _⇒_ = Machine
-    ; _≈_ = _≡_
-    ; id = idᴹ
-    ; _∘_ = _∘ᴹ_
-    ; assoc = ∘ᴹ-assoc
-    ; identityˡ = ∘ᴹ-identityˡ
-    ; identityʳ = ∘ᴹ-identityʳ
-    ; equiv = record { refl = refl ; sym = sym ; trans = trans }
-    ; ∘-resp-≈ = ∘ᴹ-resp-≡
-    }
-
-  module M = Categories.Morphism.Reasoning MACHINE
-
-  ⊗-identityʳ-helper : B ≡ I → Machine A C → Machine (A ⊗₀ B) C
-  ⊗-identityʳ-helper {A = A} refl M = M ∘ subst (λ x → Machine x A) (sym ⊗-identityʳ) CategoricalCrypto.id
-
-  ⊗ᴷ-⊗ : {M₁ : Machine A (B ⊗₀ E₁)} {M₂ : Machine C (D ⊗₀ E₂)}
-    → ∃[ π ] M₁ ⊗ᴷ M₂ ≡ π ∘ M₁ ⊗₁ M₂
-  ⊗ᴷ-⊗ = -, refl
-
-  -- this is a structure iso
-  ⊗ᴷ-⊗₁ : Machine ((A ⊗₀ B) ⊗₀ C ⊗₀ D) ((A ⊗₀ C) ⊗₀ B ⊗₀ D)
-  ⊗ᴷ-⊗₁ = proj₁ (⊗ᴷ-⊗ {M₁ = CategoricalCrypto.id} {CategoricalCrypto.id})
-
 module _ (IOF AdvF : Participant → Channel)
   (nodesF : (p : Participant) → Machine DD.M (IOF p ⊗₀ AdvF p)) honestNodes
   (honest-Node : {p : Participant} → p ∈ honestNodes → nodesF p ≡ᴹ Leios1)
@@ -211,182 +105,40 @@ module _ (IOF AdvF : Participant → Channel)
     network = DD.Network
     honest-nodes-≡-spec = honest-Node
 
-  opaque
-    safetyS : Safety LeiosBlock
-    safetyS = record { LS IsBlockchain-Leios }
+  safetyS : Safety LeiosBlock
+  safetyS = record { LS IsBlockchain-Leios }
 
   module S = Safety safetyS
 
-  opaque
-    unfolding safetyS
-    spec : Machine S.Network ((Network ⊗₀ BaseIO) ⊗₀ (I ⊗₀ I ⊗₀ BaseAdv))
-    spec = (idᴷ ⊗ᴷ B.m) ∘ᴷ liftᴷ NetTranslate
+  spec : Machine S.Network ((Network ⊗₀ BaseIO) ⊗₀ (I ⊗₀ I ⊗₀ BaseAdv))
+  spec = (idᴷ ⊗ᴷ B.m) ∘ᴷ liftᴷ NetTranslate
 
-  module Base (p : Participant) where
-    opaque
-      unfolding safetyS
-      -- Reducing `nodesF` to only the `Base` part. We can only do this to honest nodes.
-
-      IOFP : Channel
-      IOFP = case p ∈? honestNodes of λ where
-        (yes q) → Network ⊗₀ BaseIO
-        (no ¬q) → IOF p
-
-      AdvFP : Channel
-      AdvFP = case p ∈? honestNodes of λ where
-        (yes q) → I ⊗₀ I ⊗₀ BaseAdv
-        (no ¬q) → AdvF p
-
-      advTrans : AdvFP ≡ AdvF p
-      advTrans with p ∈? honestNodes
-      ... | (yes q) = trans (sym ⊗-identityʳ) (sym (⊗-injectiveʳ (_≡ᴹ_.B≡D (honest-Node q))))
-      ... | (no ¬q) = refl
-
-      praosNetwork' : Machine DD.M (IOFP ⊗₀ AdvFP)
-      praosNetwork' with p ∈? honestNodes
-      ... | (yes q) = spec
-      ... | (no ¬q) = nodesF p
-
-      praosNetwork : Machine DD.M (IOFP ⊗₀ AdvF p)
-      praosNetwork = subst (λ x → Machine DD.M (IOFP ⊗₀ x)) advTrans praosNetwork'
-
-      subst-≡ᴹ : ∀ {x y : Channel} {A B : Channel → Channel} → (eq : x ≡ y)
-        → (M : Machine (A x) (B x)) → subst (λ x → Machine (A x) (B x)) eq M ≡ᴹ M
-      subst-≡ᴹ refl _ = ≡ᴹ-refl
-
-      honest-nodes : p ∈ honestNodes → praosNetwork ≡ᴹ spec
-      honest-nodes p∈honestNodes with p ∈? honestNodes
-      ... | (yes q) = subst-≡ᴹ (trans (sym ⊗-identityʳ) (sym (⊗-injectiveʳ (_≡ᴹ_.B≡D (honest-Node q))))) spec
-      ... | (no ¬q) = contradiction p∈honestNodes ¬q
-
-      honest⇒IOF≡IO : p ∈ honestNodes → IOF p ⊗₀ I ≡ IO ⊗₀ (I ⊗₀ I) ⊗₀ I
-      honest⇒IOF≡IO p∈honestNodes = begin
-        IOF p ⊗₀ I ≡⟨ cong (_⊗₀ I) (⊗-injectiveˡ (_≡ᴹ_.B≡D (honest-Node p∈honestNodes))) ⟩
-        IO ⊗₀ I ≡⟨ cong (IO ⊗₀_) (sym ⊗-identityʳ) ⟩
-        IO ⊗₀ I ⊗₀ I ≡⟨ cong (IO ⊗₀_) (cong (_⊗₀ I) (sym ⊗-identityʳ)) ⟩
-        IO ⊗₀ (I ⊗₀ I) ⊗₀ I ∎
-        where open ≡-Reasoning
-
-      leiosPart : Machine IOFP (IOF p ⊗₀ I)
-      leiosPart with p ∈? honestNodes
-      ... | (yes q) rewrite honest⇒IOF≡IO q = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
-      ... | (no ¬q) = idᴷ
+  ext-spec : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ I)
+  ext-spec = subst (λ x → Machine (Network ⊗₀ BaseIO) (IO ⊗₀ x)) eq body
+    where
+      eq : (I ⊗₀ I) ⊗₀ I ≡ I
+      eq = trans ⊗-identityʳ ⊗-identityʳ
+      body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
+      body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
 
   module _ (IsBlockchain-spec : IsBlockchain RankingBlock spec) where
 
-    opaque
-      unfolding safetyS Base.honest-nodes
-      safetyB : Safety RankingBlock
-      safetyB = record
-        { honest-node-spec = spec
-        ; spec-IsBlockchain = IsBlockchain-spec
-        ; all-nodes = Base.praosNetwork
-        ; honest-nodes = honestNodes
-        ; honest-nodes-≡-spec = Base.honest-nodes _
-        ; network = DD.Network
-        }
+    private
+      module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+        LeiosBlock.rb LeiosBlock-Injective
+        safetyS
+        cc
+        (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
+        spec IsBlockchain-spec
+        ⊗-identityʳ
+        ext-spec
 
-    module B' = Safety safetyB
+    single-protocol-≡-ty : Type₁
+    single-protocol-≡-ty = ∀ p → idᴷ ∘ᴷ S.all-nodes p ≡ Tr.extPart p ∘ᴷ Tr.base-all-nodes p
 
-    opaque
-      unfolding safetyB
+    module _ (single-protocol-≡ : single-protocol-≡-ty) where
+      private module TrM = Tr.Main single-protocol-≡
 
-      honest-isoʳᵖ : Fin B'.n → Fin S.n
-      honest-isoʳᵖ = PL.id
-
-      honest-isoʳ : {p : Fin B'.n} → p ∈ B'.honest-nodes → honest-isoʳᵖ p ∈ S.honest-nodes
-      honest-isoʳ = PL.id
-
-      honest-isoˡᵖ : Fin S.n → Fin B'.n
-      honest-isoˡᵖ = PL.id
-
-      honest-isoˡ : {p : Fin S.n} → p ∈ S.honest-nodes → honest-isoˡᵖ p ∈ B'.honest-nodes
-      honest-isoˡ = PL.id
-
-      single-protocol-≡-ty : Type₁
-      single-protocol-≡-ty = ∀ p → idᴷ ∘ᴷ S.all-nodes p ≡ Base.leiosPart p ∘ᴷ B'.all-nodes p
-
-    module H (single-protocol-≡ : single-protocol-≡-ty) where
-      module _ {A : Channel} (E : S.Environment A) where
-        opaque
-          unfolding safetyS safetyB single-protocol-≡-ty
-
-          -- this is a structure isomorphism
-          transId : Machine
-            ((⨂ IOF ⊗₀ (⨂_ {n = numberOfParties} (const I))) ⊗₀ (DD.Env ⊗₀ DD.Adv) ⊗₀ (⨂ AdvF))
-            (⨂ IOF ⊗₀ (DD.Env ⊗₀ DD.Adv) ⊗₀ (⨂ AdvF))
-          transId = insert-id-helper AdvF ∘ (⨂-absorb-env-helper IOF)
-
-          -- this is `E`, but we absorb the Leios part of the honest participants
-          transEnv : B'.Environment A
-          transEnv = E ∘ transId ∘ ⨂ᴷ Base.leiosPart ⊗₁ CC.id
-
-          transProtocol : S.protocol E ≡ᴹ B'.protocol transEnv
-          transProtocol = flip (subst (S.protocol E ≡ᴹ_)) ≡ᴹ-refl $
-            E ∘ (S.nodes ∘ᴷ S.network) ≡⟨ insert-id S.all-nodes S.network E ⟩
-            (E ∘ insert-id-helper AdvF) ∘ (⨂ᴷ (λ p → idᴷ ∘ᴷ S.all-nodes p) ∘ᴷ S.network)
-              ≡⟨ cong (λ x → (E ∘ insert-id-helper AdvF) ∘ x ∘ᴷ S.network) (⨂ᴷ-cong single-protocol-≡) ⟩
-            (E ∘ insert-id-helper AdvF) ∘ (⨂ᴷ (λ p → Base.leiosPart p ∘ᴷ B'.all-nodes p) ∘ᴷ S.network)
-              ≡⟨ ⨂-absorb-env Base.leiosPart B'.all-nodes S.network (E ∘ insert-id-helper AdvF) ⟩
-            ((E ∘ insert-id-helper AdvF) ∘ (⨂-absorb-env-helper IOF) ∘ ⨂ᴷ Base.leiosPart ⊗₁ CC.id) ∘ ((⨂ᴷ B'.all-nodes) ∘ᴷ S.network)
-              ≡⟨ cong (_∘ (B'.nodes ∘ᴷ S.network)) (assoc²γδ {g = ⨂-absorb-env-helper IOF} {h = insert-id-helper AdvF}) ⟩
-            (E ∘ transId ∘ ⨂ᴷ Base.leiosPart ⊗₁ CC.id) ∘ (B'.nodes ∘ᴷ B'.network) ∎
-            where
-              open ≡-Reasoning
-
-          transState : Machine.State (S.protocol E) → Machine.State (B'.protocol transEnv)
-          transState = state-subst transProtocol
-
-          transTrace : {s₁ s₂ : Machine.State (S.protocol E)} → Trace (S.protocol E) s₁ s₂
-            → Trace (B'.protocol transEnv) (transState s₁) (transState s₂)
-          transTrace = Trace-subst transProtocol
-
-        LPChainLemma-ty : Type
-        LPChainLemma-ty = ∀ {p : Fin B'.n} {s} (p-honest : p ∈ B'.honest-nodes)
-          → B'.getChain transEnv (transState s) p-honest
-          ≡ map LeiosBlock.rb (S.getChain E s (honest-isoʳ p-honest))
-
-        hashCorrect-≼ : {l₁ l₂ : List LeiosBlock}
-          → map LeiosBlock.rb l₁ ≼ map LeiosBlock.rb l₂ → l₁ ≼ l₂
-        hashCorrect-≼ = inj-map-≼ LeiosBlock-Injective
-
-        module _ (LPChainLemma : LPChainLemma-ty) (s : Machine.State (S.protocol E)) where
-          open ≼-Reasoning
-          open Equivalence
-
-          opaque
-            unfolding safetyB honest-isoʳᵖ honest-isoˡᵖ
-
-            getChain-irrel : {p : Fin S.n} (hp : p ∈ S.honest-nodes)
-              → S.getChain E s hp ≡ S.getChain E s (honest-isoʳ (honest-isoˡ hp))
-            getChain-irrel _ = refl
-
-          safeState-S⇒B' : S.safeState k E s → B'.safeState k transEnv (transState s)
-          safeState-S⇒B' safe hp hp' = begin
-              prune k (B'.getChain transEnv (transState s) hp) ≡⟨ cong (prune k) (LPChainLemma hp) ⟩
-              prune k (map LeiosBlock.rb (S.getChain E s shp)) ≡⟨ prune-map {k = k} ⟩
-              map LeiosBlock.rb (prune k (S.getChain E s shp)) ≤⟨ map-≼ (safe shp shp') ⟩
-              map LeiosBlock.rb (S.getChain E s shp')          ≡⟨ LPChainLemma hp' ⟨
-              B'.getChain transEnv (transState s) hp' ∎
-            where
-              shp  = honest-isoʳ hp
-              shp' = honest-isoʳ hp'
-
-          safeState-B'⇒S : B'.safeState k transEnv (transState s) → S.safeState k E s
-          safeState-B'⇒S safe shp shp' = hashCorrect-≼ $ begin
-              map LeiosBlock.rb (prune k (S.getChain E s shp))              ≡⟨ prune-map {k = k} ⟨
-              prune k (map LeiosBlock.rb (S.getChain E s shp))              ≡⟨ cong (λ x → prune k (map {F = List} LeiosBlock.rb x)) (getChain-irrel shp) ⟩
-              prune k (map LeiosBlock.rb (S.getChain E s (honest-isoʳ hp))) ≡⟨ cong (prune k) (LPChainLemma hp) ⟨
-              prune k (B'.getChain transEnv (transState s) hp)              ≤⟨ safe hp hp' ⟩
-              B'.getChain transEnv (transState s) hp'                       ≡⟨ LPChainLemma hp' ⟩
-              map LeiosBlock.rb (S.getChain E s (honest-isoʳ hp'))          ≡⟨ cong (map LeiosBlock.rb) (getChain-irrel shp') ⟨
-              map LeiosBlock.rb (S.getChain E s shp') ∎
-            where
-              hp  = honest-isoˡ shp
-              hp' = honest-isoˡ shp'
-
-      leiosSafety : ({A : Channel} → (E : S.Environment A) → LPChainLemma-ty E)
-        → B'.safety k → S.safety k
-      leiosSafety LPChainLemma praosSafety E init final trace safeInit = safeState-B'⇒S E (LPChainLemma E) final
-          (praosSafety (transEnv E) (transState E init) (transState E final)
-            (transTrace E trace) (safeState-S⇒B' E (LPChainLemma E) init safeInit))
+      leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
+                  → Safety.safety Tr.base k → Safety.safety safetyS k
+      leiosSafety = TrM.transfer k

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -10,7 +10,7 @@ open import CategoricalCrypto.Channel.Selection
 import CategoricalCrypto as CC
 
 open import Blockchain.Safety
-open import Blockchain.Liveness as BLiveness using (Liveness)
+import Blockchain.IsBlockchain
 open import Leios.ChannelCat
 import Blockchain.Safety.Transfer as Transfer
 import Blockchain.Liveness.Transfer as LTransfer
@@ -96,10 +96,12 @@ module _ (IOF AdvF : Participant → Channel)
   (nodesF : (p : Participant) → Machine DD.M (IOF p ⊗₀ AdvF p)) honestNodes
   (honest-Node : {p : Participant} → p ∈ honestNodes → nodesF p ≡ᴹ Leios1)
   (cc : ChannelCat) (let open ChannelCat cc)
-  (IsBlockchain-Leios : IsBlockchain LeiosBlock Leios1)
+  (IsBlockchain-Leios : Blockchain.IsBlockchain.IsBlockchain LeiosBlock Participant Leios1)
   where
 
-  module LS {Block : Type} (Leios-IsBlockchain : IsBlockchain Block Leios1) where
+  module LS {Block : Type}
+    (Leios-IsBlockchain : Blockchain.IsBlockchain.IsBlockchain Block Participant Leios1) where
+    n = numberOfParties
     honest-node-spec = Leios1
     spec-IsBlockchain = Leios-IsBlockchain
     all-nodes = nodesF
@@ -123,19 +125,12 @@ module _ (IOF AdvF : Participant → Channel)
       body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
       body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
 
-  module _ (IsBlockchain-spec : IsBlockchain RankingBlock spec) where
+  module _ (IsBlockchain-spec : Blockchain.IsBlockchain.IsBlockchain RankingBlock Participant spec) where
+
+    open Blockchain.IsBlockchain RankingBlock Participant using () renaming (IsBlockchain to IsBlockchain-RB)
 
     private
       module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-        LeiosBlock.rb LeiosBlock-Injective
-        safetyS
-        cc
-        (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
-        spec IsBlockchain-spec
-        ⊗-identityʳ
-        ext-spec
-
-      module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
         LeiosBlock.rb LeiosBlock-Injective
         safetyS
         cc
@@ -154,21 +149,33 @@ module _ (IOF AdvF : Participant → Channel)
                   → Safety.safety Tr.base k → S.safety k
       leiosSafety = TrM.transfer k
 
-      module _ (baseLiv : LTr.BL.Liveness) where
+      -- Liveness transfer: provided the block-level metadata of the ext spec
+      -- factors through `LeiosBlock.rb`, HCG and ∃CQ transfer from base to ext.
+      module _ (producer-compat : ∀ b → S.producer b
+                                      ≡ IsBlockchain-RB.producer IsBlockchain-spec (LeiosBlock.rb b))
+               (slotOf-compat   : ∀ b → S.slotOf b
+                                      ≡ IsBlockchain-RB.slotOf IsBlockchain-spec (LeiosBlock.rb b))
+        where
 
-        private module LTrM = LTr.Main baseLiv single-protocol-≡
+        private
+          module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+            LeiosBlock.rb LeiosBlock-Injective
+            safetyS
+            cc
+            (Network ⊗₀ BaseIO) (I ⊗₀ I ⊗₀ BaseAdv)
+            spec IsBlockchain-spec
+            ⊗-identityʳ
+            ext-spec
+            producer-compat slotOf-compat
 
-        leiosLiveness : LTr.EL.Liveness
-        leiosLiveness = LTr.extLiv baseLiv
+          module LTrM = LTr.Main single-protocol-≡
 
         leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
                  → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-                 → ∀ τ → LTr.BL.Liveness.hcg baseLiv τ
-                       → LTr.EL.Liveness.hcg leiosLiveness τ
+                 → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
         leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
 
         leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
                  → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-                 → ∀ T → LTr.BL.Liveness.∃cq baseLiv T
-                       → LTr.EL.Liveness.∃cq leiosLiveness T
+                 → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
         leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -13,7 +13,7 @@ open import Categories.Category
 open import Categories.Category.Helper
 import Categories.Morphism.Reasoning
 
-open import Leios.Safety
+open import Blockchain.Safety
 
 module Network.Leios
   (⋯ : SpecStructure) (let open SpecStructure ⋯)

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -139,39 +139,33 @@ module _ (IOF AdvF : Participant → Channel)
     private
       module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
         safetyS base-spec cc extension
+      module TrM = Tr.Main
 
-    single-protocol-≡-ty : Type₁
-    single-protocol-≡-ty = ∀ p → idᴷ ∘ᴷ S.all-nodes p ≡ Tr.extPart p ∘ᴷ Tr.base-all-nodes p
+    leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
+                → Safety.safety Tr.base k → S.safety k
+    leiosSafety = TrM.transfer k
 
-    module _ (single-protocol-≡ : single-protocol-≡-ty) where
-      private module TrM = Tr.Main single-protocol-≡
+    -- Liveness transfer additionally requires the two block-level
+    -- compatibility witnesses.
+    module _ (producer-compat : ∀ b → S.producer b
+                                    ≡ Spec.producer base-spec
+                                        (IsExtension.getBaseBlock extension b))
+             (slotOf-compat   : ∀ b → S.slotOf b
+                                    ≡ Spec.slotOf base-spec
+                                        (IsExtension.getBaseBlock extension b))
+      where
 
-      leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
-                  → Safety.safety Tr.base k → S.safety k
-      leiosSafety = TrM.transfer k
+      private
+        module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+          safetyS base-spec cc extension producer-compat slotOf-compat
+        module LTrM = LTr.Main
 
-      -- Liveness transfer additionally requires the two block-level
-      -- compatibility witnesses.
-      module _ (producer-compat : ∀ b → S.producer b
-                                      ≡ Spec.producer base-spec
-                                          (IsExtension.getBaseBlock extension b))
-               (slotOf-compat   : ∀ b → S.slotOf b
-                                      ≡ Spec.slotOf base-spec
-                                          (IsExtension.getBaseBlock extension b))
-        where
+      leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+               → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
+      leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
 
-        private
-          module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-            safetyS base-spec cc extension producer-compat slotOf-compat
-
-          module LTrM = LTr.Main single-protocol-≡
-
-        leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-                 → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
-        leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
-
-        leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-                 → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-                 → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
-        leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL
+      leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+               → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
+      leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -9,9 +9,9 @@ open import CategoricalCrypto hiding (id)
 open import CategoricalCrypto.Channel.Selection
 import CategoricalCrypto as CC
 
-open import Leios.Safety
+open import Blockchain.Safety
 open import Leios.ChannelCat
-import Leios.Safety.Transfer as Transfer
+import Blockchain.Safety.Transfer as Transfer
 
 module Network.Leios
   (⋯ : SpecStructure) (let open SpecStructure ⋯)

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -10,7 +10,7 @@ open import CategoricalCrypto.Channel.Selection
 import CategoricalCrypto as CC
 
 open import Blockchain.Safety
-import Blockchain.IsBlockchain
+import Blockchain.IsBlockchain as IsBC
 open import Leios.ChannelCat
 import Blockchain.Safety.Transfer as Transfer
 import Blockchain.Liveness.Transfer as LTransfer
@@ -96,14 +96,14 @@ module _ (IOF AdvF : Participant → Channel)
   (nodesF : (p : Participant) → Machine DD.M (IOF p ⊗₀ AdvF p)) honestNodes
   (honest-Node : {p : Participant} → p ∈ honestNodes → nodesF p ≡ᴹ Leios1)
   (cc : ChannelCat) (let open ChannelCat cc)
-  (IsBlockchain-Leios : Blockchain.IsBlockchain.IsBlockchain Participant LeiosBlock Leios1)
+  (IsBlockchain-Leios : IsBC.IsBlockchain Participant LeiosBlock Leios1)
   where
 
   module LS {Block : Type}
-    (Leios-IsBlockchain : Blockchain.IsBlockchain.IsBlockchain Participant Block Leios1) where
+    (IsBlockchain-Block : IsBC.IsBlockchain Participant Block Leios1) where
     n = numberOfParties
     honest-node-spec = Leios1
-    spec-IsBlockchain = Leios-IsBlockchain
+    spec-IsBlockchain = IsBlockchain-Block
     all-nodes = nodesF
     honest-nodes = honestNodes
     network = DD.Network
@@ -125,12 +125,12 @@ module _ (IOF AdvF : Participant → Channel)
       body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
       body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
 
-  module _ (IsBlockchain-spec : Blockchain.IsBlockchain.IsBlockchain Participant RankingBlock spec)
-           (compat : Blockchain.IsBlockchain.IsBlockchain-compatible
+  module _ (IsBlockchain-spec : IsBC.IsBlockchain Participant RankingBlock spec)
+           (compat : IsBC.IsBlockchain-compatible
                        Participant IsBlockchain-spec (Safety.spec-IsBlockchain safetyS))
            where
 
-    open Blockchain.IsBlockchain.IsBlockchain-compatible compat
+    open IsBC.IsBlockchain-compatible compat
 
     private
       module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -92,11 +92,15 @@ LeiosBlock-Injective
   subst (λ (eb , correct) → _ ≡ record { rb = rb ; eb = eb ; correct = correct })
     (hash-unique' rb eb₁ eb₂ correct₁ correct₂) refl
 
+spec : Machine DD.M ((Network ⊗₀ BaseIO) ⊗₀ (I ⊗₀ I ⊗₀ BaseAdv))
+spec = (idᴷ ⊗ᴷ B.m) ∘ᴷ liftᴷ NetTranslate
+
 module _ (IOF AdvF : Participant → Channel)
   (nodesF : (p : Participant) → Machine DD.M (IOF p ⊗₀ AdvF p)) honestNodes
   (honest-Node : {p : Participant} → p ∈ honestNodes → nodesF p ≡ᴹ Leios1)
   (cc : ChannelCat) (let open ChannelCat cc)
   (IsBlockchain-Leios : IsBC.IsBlockchain Participant LeiosBlock Leios1)
+  (IsBlockchain-base : IsBC.IsBlockchain Participant RankingBlock spec)
   where
 
   safetyS : Safety LeiosBlock
@@ -122,9 +126,6 @@ module _ (IOF AdvF : Participant → Channel)
 
   module S = Safety safetyS
 
-  spec : Machine S.Network ((Network ⊗₀ BaseIO) ⊗₀ (I ⊗₀ I ⊗₀ BaseAdv))
-  spec = (idᴷ ⊗ᴷ B.m) ∘ᴷ liftᴷ NetTranslate
-
   ext-spec : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ I)
   ext-spec = subst (λ x → Machine (Network ⊗₀ BaseIO) (IO ⊗₀ x)) eq body
     where
@@ -133,8 +134,15 @@ module _ (IOF AdvF : Participant → Channel)
       body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
       body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
 
-  module _ (base-spec : Spec RankingBlock S.n S.Network)
-           (extension : IsExtension base-spec (Safety.spec safetyS)) where
+  base-spec : Spec RankingBlock S.n S.Network
+  base-spec = record
+    { IO                = _
+    ; Adv               = _
+    ; honest-node-spec  = spec
+    ; spec-IsBlockchain = IsBlockchain-base
+    }
+
+  module _ (extension : IsExtension base-spec (Safety.spec safetyS)) where
 
     private
       module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -22,7 +22,9 @@ module Network.Leios
   (HashCorrectB : RankingBlock → Maybe EndorserBlock → Type)
   (HashCorrect-irrel : ∀ rb eb → Irrelevant (HashCorrectB rb eb))
   (hash-unique : (rb : RankingBlock) → (eb₁ eb₂ : Maybe EndorserBlock)
-    → HashCorrectB rb eb₁ → HashCorrectB rb eb₂ → eb₁ ≡ eb₂) where
+    → HashCorrectB rb eb₁ → HashCorrectB rb eb₂ → eb₁ ≡ eb₂)
+  (cc : ChannelCat) (let open ChannelCat cc)
+    where
 
 open import Leios.Linear ⋯ params
 open Types params hiding (Network)
@@ -95,13 +97,22 @@ LeiosBlock-Injective
 spec : Machine DD.M ((Network ⊗₀ BaseIO) ⊗₀ (I ⊗₀ I ⊗₀ BaseAdv))
 spec = (idᴷ ⊗ᴷ B.m) ∘ᴷ liftᴷ NetTranslate
 
+ext-spec : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ I)
+ext-spec = subst (λ x → Machine (Network ⊗₀ BaseIO) (IO ⊗₀ x)) eq body
+  where
+    eq : (I ⊗₀ I) ⊗₀ I ≡ I
+    eq = trans ⊗-identityʳ ⊗-identityʳ
+    body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
+    body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
+
 module _ (IOF AdvF : Participant → Channel)
   (nodesF : (p : Participant) → Machine DD.M (IOF p ⊗₀ AdvF p)) honestNodes
   (honest-Node : {p : Participant} → p ∈ honestNodes → nodesF p ≡ᴹ Leios1)
-  (cc : ChannelCat) (let open ChannelCat cc)
   (IsBlockchain-Leios : IsBC.IsBlockchain Participant LeiosBlock Leios1)
   (IsBlockchain-base : IsBC.IsBlockchain Participant RankingBlock spec)
-  where
+  (is-extension-eq :
+    idᴷ ∘ᴷ Leios1 ≡ subst (λ A → Machine DD.M (IO ⊗₀ (A ⊗₀ I))) (sym ⊗-identityʳ) (ext-spec ∘ᴷ spec))
+    where
 
   safetyS : Safety LeiosBlock
   safetyS = record
@@ -126,14 +137,6 @@ module _ (IOF AdvF : Participant → Channel)
 
   module S = Safety safetyS
 
-  ext-spec : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ I)
-  ext-spec = subst (λ x → Machine (Network ⊗₀ BaseIO) (IO ⊗₀ x)) eq body
-    where
-      eq : (I ⊗₀ I) ⊗₀ I ≡ I
-      eq = trans ⊗-identityʳ ⊗-identityʳ
-      body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
-      body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
-
   base-spec : Spec RankingBlock S.n S.Network
   base-spec = record
     { IO                = _
@@ -142,38 +145,45 @@ module _ (IOF AdvF : Participant → Channel)
     ; spec-IsBlockchain = IsBlockchain-base
     }
 
-  module _ (extension : IsExtension base-spec (Safety.spec safetyS)) where
+  extension : IsExtension base-spec (Safety.spec safetyS)
+  extension = record
+    { ext-Adv≡base-Adv = ⊗-identityʳ
+    ; ext-layer        = ext-spec
+    ; is-extension     = is-extension-eq
+    ; getBaseBlock     = LeiosBlock.rb
+    ; getBaseBlock-inj = LeiosBlock-Injective
+    }
+
+  private
+    module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+      safetyS base-spec cc extension
+    module TrM = Tr.Main
+
+  leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
+              → Safety.safety Tr.base k → S.safety k
+  leiosSafety = TrM.transfer k
+
+  -- Liveness transfer additionally requires the two block-level
+  -- compatibility witnesses.
+  module _ (producer-compat : ∀ b → S.producer b
+                                  ≡ Spec.producer base-spec
+                                      (IsExtension.getBaseBlock extension b))
+           (slotOf-compat   : ∀ b → S.slotOf b
+                                  ≡ Spec.slotOf base-spec
+                                      (IsExtension.getBaseBlock extension b))
+    where
 
     private
-      module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-        safetyS base-spec cc extension
-      module TrM = Tr.Main
+      module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
+        safetyS base-spec cc extension producer-compat slotOf-compat
+      module LTrM = LTr.Main
 
-    leiosSafety : (∀ {A} (E : Safety.Environment safetyS A) → TrM.ChainLemma-ty E)
-                → Safety.safety Tr.base k → S.safety k
-    leiosSafety = TrM.transfer k
+    leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+             → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+             → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
+    leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
 
-    -- Liveness transfer additionally requires the two block-level
-    -- compatibility witnesses.
-    module _ (producer-compat : ∀ b → S.producer b
-                                    ≡ Spec.producer base-spec
-                                        (IsExtension.getBaseBlock extension b))
-             (slotOf-compat   : ∀ b → S.slotOf b
-                                    ≡ Spec.slotOf base-spec
-                                        (IsExtension.getBaseBlock extension b))
-      where
-
-      private
-        module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-          safetyS base-spec cc extension producer-compat slotOf-compat
-        module LTrM = LTr.Main
-
-      leiosHCG : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-               → ∀ τ → LTr.BL.hcg τ → LTr.EL.hcg τ
-      leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
-
-      leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
-               → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
-               → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
-      leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL
+    leios∃CQ : (∀ {A} (E : S.Environment A) → LTrM.TrM.ChainLemma-ty E)
+             → (∀ {A} (E : S.Environment A) → LTrM.SlotLemma-ty E)
+             → ∀ T → LTr.BL.∃cq T → LTr.EL.∃cq T
+    leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -167,12 +167,12 @@ module _ (IOF AdvF : Participant → Channel)
 
         leiosHCG : (∀ {A} (E : Safety.Environment safetyS A) → LTrM.TrM.ChainLemma-ty E)
                  → (∀ {A} (E : Safety.Environment safetyS A) → LTrM.SlotLemma-ty E)
-                 → ∀ τ → BLiveness.Liveness.hcg RankingBlock Tr.base baseLiv τ
-                       → BLiveness.Liveness.hcg LeiosBlock safetyS leiosLiveness τ
+                 → ∀ τ → LTr.BL.Liveness.hcg baseLiv τ
+                       → LTr.EL.Liveness.hcg leiosLiveness τ
         leiosHCG CL SL τ = LTrM.hcg-transfer τ CL SL
 
         leios∃CQ : (∀ {A} (E : Safety.Environment safetyS A) → LTrM.TrM.ChainLemma-ty E)
                  → (∀ {A} (E : Safety.Environment safetyS A) → LTrM.SlotLemma-ty E)
-                 → ∀ T → BLiveness.Liveness.∃cq RankingBlock Tr.base baseLiv T
-                       → BLiveness.Liveness.∃cq LeiosBlock safetyS leiosLiveness T
+                 → ∀ T → LTr.BL.Liveness.∃cq baseLiv T
+                       → LTr.EL.Liveness.∃cq leiosLiveness T
         leios∃CQ CL SL T = LTrM.∃cq-transfer T CL SL

--- a/formal-spec/Network/Leios.agda
+++ b/formal-spec/Network/Leios.agda
@@ -133,11 +133,12 @@ module _ (IOF AdvF : Participant → Channel)
       body : Machine (Network ⊗₀ BaseIO) (IO ⊗₀ ((I ⊗₀ I) ⊗₀ I))
       body = LinearLeios ∘ᴷ (liftᴷ Shim ⊗ᴷ idᴷ)
 
-  module _ (extension : IsExtension {RankingBlock} (Safety.spec safetyS)) where
+  module _ (base-spec : Spec RankingBlock S.n S.Network)
+           (extension : IsExtension base-spec (Safety.spec safetyS)) where
 
     private
       module Tr = Transfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-        safetyS cc extension
+        safetyS base-spec cc extension
 
     single-protocol-≡-ty : Type₁
     single-protocol-≡-ty = ∀ p → idᴷ ∘ᴷ S.all-nodes p ≡ Tr.extPart p ∘ᴷ Tr.base-all-nodes p
@@ -152,18 +153,16 @@ module _ (IOF AdvF : Participant → Channel)
       -- Liveness transfer additionally requires the two block-level
       -- compatibility witnesses.
       module _ (producer-compat : ∀ b → S.producer b
-                                      ≡ IsBC.IsBlockchain.producer
-                                          (IsExtension.base-IsBlockchain extension)
+                                      ≡ Spec.producer base-spec
                                           (IsExtension.getBaseBlock extension b))
                (slotOf-compat   : ∀ b → S.slotOf b
-                                      ≡ IsBC.IsBlockchain.slotOf
-                                          (IsExtension.base-IsBlockchain extension)
+                                      ≡ Spec.slotOf base-spec
                                           (IsExtension.getBaseBlock extension b))
         where
 
         private
           module LTr = LTransfer {BlockExt = LeiosBlock} {BlockBase = RankingBlock}
-            safetyS cc extension producer-compat slotOf-compat
+            safetyS base-spec cc extension producer-compat slotOf-compat
 
           module LTrM = LTr.Main single-protocol-≡
 

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -148,9 +148,9 @@ data d-BaseRel : machine-type d-BaseState d-BaseChannel where
         (just (L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BaseAbstract.SLOT slot))
         (blocks , slot)
 
-open Blockchain.IsBlockchain RankingBlock (Fin 1)
+open Blockchain.IsBlockchain (Fin 1)
 
-helper : BlockChainInfo → BaseAbstract.BaseIOF d-Base CategoricalCrypto.Out
+helper : BlockChainInfo RankingBlock → BaseAbstract.BaseIOF d-Base CategoricalCrypto.Out
 helper = let open BaseAbstract.BaseIOF in λ where
   Chain → FTCH-LDG
   Slot  → FTCH-SLOT

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -14,6 +14,7 @@ open import Leios.Abstract
 open import Leios.Config
 open import Leios.SpecStructure
 open import Blockchain.Safety
+import Blockchain.IsBlockchain
 
 open import Axiom.Set.Properties th
 open import Data.Nat.Show as N
@@ -147,7 +148,9 @@ data d-BaseRel : machine-type d-BaseState d-BaseChannel where
         (just (L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BaseAbstract.SLOT slot))
         (blocks , slot)
 
-helper : BlockChainInfo RankingBlock → BaseAbstract.BaseIOF d-Base CategoricalCrypto.Out
+open Blockchain.IsBlockchain RankingBlock (Fin 1)
+
+helper : BlockChainInfo → BaseAbstract.BaseIOF d-Base CategoricalCrypto.Out
 helper = let open BaseAbstract.BaseIOF in λ where
   Chain → FTCH-LDG
   Slot  → FTCH-SLOT
@@ -181,7 +184,8 @@ private
 d-BaseFunctionality : BaseAbstract.BaseMachine d-Base
 d-BaseFunctionality =
   record
-    { m =
+    { n = 1
+    ; m =
         record
           { State = (List RankingBlock × ℕ)
           ; stepRel = d-BaseRel
@@ -204,6 +208,8 @@ d-BaseFunctionality =
           ; isPure = λ where
               Chain → isPure-chain
               Slot  → isPure-slot
+          ; producer = λ _ → Fin.zero
+          ; slotOf   = λ _ → 0
           }
     }
 

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -13,7 +13,7 @@ open import Leios.Prelude hiding (_⊗_)
 open import Leios.Abstract
 open import Leios.Config
 open import Leios.SpecStructure
-open import Leios.Safety
+open import Blockchain.Safety
 
 open import Axiom.Set.Properties th
 open import Data.Nat.Show as N

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -13,7 +13,7 @@ open import Leios.Prelude hiding (_⊗_)
 open import Leios.Abstract
 open import Leios.Config
 open import Leios.SpecStructure
-open import Leios.Safety
+open import Blockchain.Safety
 
 open import Axiom.Set.Properties th
 open import Data.Nat.Show as N
@@ -139,8 +139,44 @@ data d-BaseRel : machine-type d-BaseState d-BaseChannel where
         (just (L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BaseAbstract.BASE-LDG blocks))
         (blocks , slot)
 
+  fetch-slot :
+    ∀ blocks slot →
+      d-BaseRel
+        (blocks , slot)
+        (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ BaseAbstract.FTCH-SLOT)
+        (just (L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BaseAbstract.SLOT slot))
+        (blocks , slot)
+
 helper : BlockChainInfo RankingBlock → BaseAbstract.BaseIOF d-Base CategoricalCrypto.Out
-helper = let open BaseAbstract.BaseIOF in λ {Chain → FTCH-LDG}
+helper = let open BaseAbstract.BaseIOF in λ where
+  Chain → FTCH-LDG
+  Slot  → FTCH-SLOT
+
+private
+  open BaseAbstract.BaseIOF
+
+  opaque
+    unfolding _⊗₀_
+
+    correctness-chain : ∀ {s response' s'}
+      → d-BaseRel s (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ FTCH-LDG) response' s'
+      → ∃ λ response → response' ≡ just (L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BASE-LDG response)
+    correctness-chain (fetch-blocks blocks _) = blocks , refl
+
+    correctness-slot : ∀ {s response' s'}
+      → d-BaseRel s (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ FTCH-SLOT) response' s'
+      → ∃ λ response → response' ≡ just (L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ SLOT response)
+    correctness-slot (fetch-slot _ slot) = slot , refl
+
+    isPure-chain : ∀ {s response' s'}
+      → d-BaseRel s (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ FTCH-LDG) response' s'
+      → s ≡ s'
+    isPure-chain (fetch-blocks _ _) = refl
+
+    isPure-slot : ∀ {s response' s'}
+      → d-BaseRel s (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ FTCH-SLOT) response' s'
+      → s ≡ s'
+    isPure-slot (fetch-slot _ _) = refl
 
 d-BaseFunctionality : BaseAbstract.BaseMachine d-Base
 d-BaseFunctionality =
@@ -149,7 +185,7 @@ d-BaseFunctionality =
         record
           { State = (List RankingBlock × ℕ)
           ; stepRel = d-BaseRel
-          } 
+          }
     ; is-blockchain = let open BaseAbstract.BaseIOF in
         record
           { isConstrained =
@@ -157,17 +193,17 @@ d-BaseFunctionality =
                 { queryI = (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ_) ∘ helper
                 ; queryO = λ where
                     {Chain} rankingBlocks → L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BASE-LDG rankingBlocks
+                    {Slot}  slot          → L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ SLOT slot
                 ; correctness = λ where
-                    {Chain} {s} {response'} {s'} x → case (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ FTCH-LDG) of-≡
-                      λ _ eq → case subst (λ i → d-BaseRel s i response' s') eq x of λ where
-                        (fetch-blocks blocks _) → blocks , refl
+                    {Chain} → correctness-chain
+                    {Slot}  → correctness-slot
                 ; completeness = λ where
                     {Chain} {blocks , slot} → L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BaseAbstract.BASE-LDG blocks , (blocks , slot) , fetch-blocks blocks slot
+                    {Slot}  {blocks , slot} → L⊗ (ϵ ⊗R) ᵗ¹ ↑ᵢ BaseAbstract.SLOT     slot   , (blocks , slot) , fetch-slot   blocks slot
                 }
           ; isPure = λ where
-              Chain {s} {s'} {response'} x → case (L⊗ (ϵ ⊗R) ᵗ¹ ↑ₒ FTCH-LDG) of-≡
-                λ _ eq → case subst (λ i → d-BaseRel s i response' s') eq x of λ where
-                  (fetch-blocks _ _) → refl
+              Chain → isPure-chain
+              Slot  → isPure-slot
           }
     }
 

--- a/formal-spec/formal-spec.lagda.md
+++ b/formal-spec/formal-spec.lagda.md
@@ -69,6 +69,7 @@ open import Leios.Linear
 Category-theoretic approach to cryptography
 ```agda
 open import CategoricalCrypto
+import CategoricalCrypto.Ext
 ```
 ### Blockchain abstractions
 ```agda

--- a/formal-spec/formal-spec.lagda.md
+++ b/formal-spec/formal-spec.lagda.md
@@ -70,6 +70,10 @@ Category-theoretic approach to cryptography
 ```agda
 open import CategoricalCrypto
 ```
+### Blockchain abstractions
+```agda
+import Blockchain.Liveness.Transfer
+```
 ### Network Layer
 Basic broadcast networking primitives
 ```agda


### PR DESCRIPTION
This is a relatively big PR, almost entirely generated by Claude. It does a few things:
- Move the safety statement into `Blockchain.Safety`, and add liveness statements in `Blockchain.Liveness` (honest chain growth and existential chain quality)
- Refactor the safety proof into a Leios independent part `Blockchain.Safety.Transfer`
- Add a similar module for liveness `Blockchain.Liveness.Transfer`
- Redo all the plumbing that was part of the `Safety` record so it makes a lot more sense