### PR TITLE
Align VT-Role voting rules with published CIP-0164

### DIFF
--- a/formal-spec/Leios/Config.lagda.md
+++ b/formal-spec/Leios/Config.lagda.md
@@ -29,9 +29,7 @@ record NetworkParams : Type where
 record Params : Type where
   field networkParams    : NetworkParams
         Lhdr Lvote Ldiff : ℕ
-        -- CIP-0164 committee stake coverage σc, as a ratio σc-num / σc-den
-        -- (e.g. 99 / 100): the voting committee is the stake-descending
-        -- prefix of pools whose cumulative stake reaches σc of the total.
+        -- stake coverage σc, as a ratio σc-num / σc-den
         σc-num σc-den    : ℕ
 
   open NetworkParams networkParams public
@@ -49,14 +47,13 @@ module _ (params : Params) where
     -- stake held by pools with strictly more stake than the given one
     richerStake : ℕ → ℕ
     richerStake st = L.sum (L.filter (st <?_) allStakes)
-
-  -- Voting-committee membership by stake-based truncation (CIP-0164,
-  -- "Committee Structure"): order pools by stake descending and accumulate
-  -- until the cumulative stake covers the σc target; the committee is fixed
-  -- for the whole epoch. A pool with stake `st` is on the committee iff the
-  -- pools with strictly more stake do not already cover the target. Pools of
-  -- equal stake at the boundary are all included (the CIP fixes no tie
-  -- order).
+```
+Voting-committee membership by stake-based truncation: order pools by
+stake descending and accumulate until the cumulative stake covers the σc
+target; the committee is fixed for the whole epoch. A pool with stake `st`
+is on the committee iff the pools with strictly more stake do not already
+cover the target. Pools of equal stake at the boundary are all included.
+```agda
   inVotingCommittee : ℕ → Type
   inVotingCommittee st = richerStake st * σc-den < totalStake * σc-num
 

--- a/formal-spec/Leios/Config.lagda.md
+++ b/formal-spec/Leios/Config.lagda.md
@@ -64,5 +64,5 @@ record TestParams (params : Params) : Type where
   open Params params
 
   field sutId : Fin numberOfParties
-        winning-slots : ℙ (BlockType × ℕ)
+        winning-slots : ℙ ℕ
 ```

--- a/formal-spec/Leios/Config.lagda.md
+++ b/formal-spec/Leios/Config.lagda.md
@@ -29,8 +29,36 @@ record NetworkParams : Type where
 record Params : Type where
   field networkParams    : NetworkParams
         Lhdr Lvote Ldiff : ℕ
+        -- CIP-0164 committee stake coverage σc, as a ratio σc-num / σc-den
+        -- (e.g. 99 / 100): the voting committee is the stake-descending
+        -- prefix of pools whose cumulative stake reaches σc of the total.
+        σc-num σc-den    : ℕ
 
   open NetworkParams networkParams public
+
+module _ (params : Params) where
+  open Params params
+
+  private
+    allStakes : List ℕ
+    allStakes = L.tabulate (TotalMap.lookup stakeDistribution)
+
+    totalStake : ℕ
+    totalStake = L.sum allStakes
+
+    -- stake held by pools with strictly more stake than the given one
+    richerStake : ℕ → ℕ
+    richerStake st = L.sum (L.filter (st <?_) allStakes)
+
+  -- Voting-committee membership by stake-based truncation (CIP-0164,
+  -- "Committee Structure"): order pools by stake descending and accumulate
+  -- until the cumulative stake covers the σc target; the committee is fixed
+  -- for the whole epoch. A pool with stake `st` is on the committee iff the
+  -- pools with strictly more stake do not already cover the target. Pools of
+  -- equal stake at the boundary are all included (the CIP fixes no tie
+  -- order).
+  inVotingCommittee : ℕ → Type
+  inVotingCommittee st = richerStake st * σc-den < totalStake * σc-num
 
 record TestParams (params : Params) : Type where
   open Params params

--- a/formal-spec/Leios/Linear.lagda.md
+++ b/formal-spec/Leios/Linear.lagda.md
@@ -140,15 +140,10 @@ mempool.
           ∙ EndorserBlockOSig.txs eb ≢ []
           ∙ needsUpkeep VT-Role
           ∙ inVotingCommittee params (stake s)
-          -- Only a pool with a registered voting key may sign (CIP-0164,
-          -- "Key Registration and Rotation"): a pool selected by stake
-          -- without a registered key holds a *keyless* committee seat and
-          -- must abstain.
+          -- Only a pool with a registered voting key may sign
           ∙ id ∈ˡ L.map poolID PubKeys
           ───────────────────────────────────────────────────────
           s ↝ ( rememberVote (addUpkeep s VT-Role) eb
-              -- the vote signs the hash of the announcing RB (CIP-0164,
-              -- "Vote Structure")
               , Send (vtHeader [ vote sk-VT (hash currentRB) ]) nothing)
 ```
 Predicate needed for slot transition. Special care needs to be taken when starting from
@@ -157,12 +152,12 @@ genesis.
 allDone : LeiosState → Type
 allDone record { Upkeep = u } = VT-Role ∈ˡ u × EB-Role ∈ˡ u × Base ∈ˡ u
 ```
-Voting happens within a window (CIP-0164, "Committee Validation"): it opens
-`3 * Lhdr` slots after the announcing RB's slot (the equivocation-detection
-period) and closes `Lvote` slots later. `voteDeadline` is the last slot at
-which the current EB may still be voted on; when there is no current EB (or it
-has not been received yet) the deadline is `0`, so the deferral rule `Roles₃`
-below is vacuously inapplicable and abstention is governed solely by `Roles₂`.
+Voting happens within a window: it opens `3 * Lhdr` slots after the announcing
+RB's slot (the equivocation-detection period) and closes `Lvote` slots later.
+`voteDeadline` is the last slot at which the current EB may still be voted on;
+when there is no current EB (or it has not been received yet) the deadline is `0`,
+so the deferral rule `Roles₃` below is vacuously inapplicable and abstention is
+governed solely by `Roles₂`.
 ```agda
 voteDeadline : LeiosState → ℕ
 voteDeadline s = let open LeiosState s in
@@ -240,23 +235,13 @@ Note: Submitted data to the base chain is only taken into account
          ∙ u ≢ Base
          ──────────────────────────────────────────────────
          s -⟦ (ϵ ⊗R) ⊗R ↑ᵢ SLOT / nothing ⟧⇀ addUpkeep s u
-
-  -- Deferral of the VT-Role (CIP-0164 voting window): abstaining from voting
-  -- is permitted while the current EB's voting window is still open
-  -- (`slot < voteDeadline`), even when a positive VT-Role step could fire.
-  -- Together with `Roles₂` this yields bounded liveness: at the deadline slot
-  -- neither `Roles₃` (window closes) nor `Roles₂` (a vote can still fire)
-  -- applies, so a vote must be cast by then.
-  --
-  -- Note the deadline forces a vote only if a VT-Role step is still possible.
-  -- In particular, a vote provided earlier in the window does not get forced
-  -- again: `rememberVote` records the EB in `VotedEBs`, which persists in
-  -- 'LeiosState' (unlike the per-slot `Upkeep`), so VT-Role's
-  -- `hash eb ∉ VotedEBs` premise blocks any re-vote and `Roles₂` then licenses
-  -- abstention at and after the deadline. The same holds when no vote step
-  -- ever becomes possible (ineligible, EB received after `Lhdr`, invalid or
-  -- empty EB): abstention goes through `Roles₂` at every slot; `Roles₃` is
-  -- only needed while an eligible voter is still deliberating.
+```
+Deferral of the VT-Role: abstaining from voting is permitted while the
+current EB's voting window is still open, even when a positive VT-Role
+step could fire. Together with `Roles₂` this yields bounded liveness:
+at the deadline slot neither `Roles₃` (window closes) nor `Roles₂` (a vote can still fire)
+applies, so a vote must be cast by then.
+```agda
   Roles₃ : let open LeiosState s in
          ∙ slot < voteDeadline s
          ∙ needsUpkeep VT-Role

--- a/formal-spec/Leios/Linear.lagda.md
+++ b/formal-spec/Leios/Linear.lagda.md
@@ -139,7 +139,7 @@ mempool.
           ∙ isValidityChecked slot eb
           ∙ EndorserBlockOSig.txs eb ≢ []
           ∙ needsUpkeep VT-Role
-          ∙ inVotingCommittee sk-VT (stake s)
+          ∙ inVotingCommittee params (stake s)
           ───────────────────────────────────────────────────────
           s ↝ ( rememberVote (addUpkeep s VT-Role) eb
               , Send (vtHeader [ vote sk-VT (hash eb) ]) nothing)

--- a/formal-spec/Leios/Linear.lagda.md
+++ b/formal-spec/Leios/Linear.lagda.md
@@ -36,7 +36,8 @@ In addition to the expected paramaters, we assume a two functions:
 - `splitTxs`: produces a pair of a list of transactions that can be
   included in an RB and a list of transactions that can be included in
   an EB
-- `validityCheckTime`: the time it takes to validate a given EB (in slots)
+- `isValidityChecked`: whether validation of a given EB has completed by a
+  given slot
 
 ### Upkeep
 
@@ -135,7 +136,7 @@ mempool.
           ∙ slot' ≤ slotNumber eb + Lhdr
           ∙ slotNumber eb + 3 * Lhdr ≤ slot
           ∙ slot ≤ slotNumber eb + 3 * Lhdr + Lvote
-          ∙ validityCheckTime eb ≤ 3 * Lhdr + Lvote
+          ∙ isValidityChecked slot eb
           ∙ EndorserBlockOSig.txs eb ≢ []
           ∙ needsUpkeep VT-Role
           ∙ inVotingCommittee sk-VT (stake s)
@@ -263,6 +264,9 @@ LinearLeios .Machine.stepRel = _-⟦_/_⟧⇀_
 instance
   Dec-isValid : ∀ {s x} → isValid s x ⁇
   Dec-isValid {s} {x} = ⁇ isValid? s x
+
+  Dec-isValidityChecked : ∀ {n eb} → isValidityChecked n eb ⁇
+  Dec-isValidityChecked {n} {eb} = ⁇ isValidityChecked? n eb
 
 unquoteDecl EB-Role-premises = genPremises EB-Role-premises (quote _↝_.EB-Role)
 unquoteDecl VT-Role-premises = genPremises VT-Role-premises (quote _↝_.VT-Role)

--- a/formal-spec/Leios/Linear.lagda.md
+++ b/formal-spec/Leios/Linear.lagda.md
@@ -134,11 +134,11 @@ mempool.
           ∙ isValid s (inj₁ (ebHeader eb))
           ∙ slot' ≤ slotNumber eb + Lhdr
           ∙ slotNumber eb + 3 * Lhdr ≤ slot
-          ∙ slot ≡ slotNumber eb + (3 * Lhdr ⊔ validityCheckTime eb)
+          ∙ slot ≤ slotNumber eb + 3 * Lhdr + Lvote
           ∙ validityCheckTime eb ≤ 3 * Lhdr + Lvote
           ∙ EndorserBlockOSig.txs eb ≢ []
           ∙ needsUpkeep VT-Role
-          ∙ canProduceV (slotNumber eb) sk-VT (stake s)
+          ∙ inVotingCommittee sk-VT (stake s)
           ───────────────────────────────────────────────────────
           s ↝ ( rememberVote (addUpkeep s VT-Role) eb
               , Send (vtHeader [ vote sk-VT (hash eb) ]) nothing)
@@ -148,6 +148,21 @@ genesis.
 ```agda
 allDone : LeiosState → Type
 allDone record { Upkeep = u } = VT-Role ∈ˡ u × EB-Role ∈ˡ u × Base ∈ˡ u
+```
+Voting happens within a window (CIP-0164, "Committee Validation"): it opens
+`3 * Lhdr` slots after the announcing RB's slot (the equivocation-detection
+period) and closes `Lvote` slots later. `voteDeadline` is the last slot at
+which the current EB may still be voted on; when there is no current EB (or it
+has not been received yet) the deadline is `0`, so the deferral rule `Roles₃`
+below is vacuously inapplicable and abstention is governed solely by `Roles₂`.
+```agda
+voteDeadline : LeiosState → ℕ
+voteDeadline s = let open LeiosState s in
+  case getCurrentEBHash s of λ where
+    nothing       → 0
+    (just ebHash) → case find (λ (_ , eb') → hash eb' ≟ ebHash) EBs' of λ where
+      nothing         → 0
+      (just (_ , eb)) → slotNumber eb + 3 * Lhdr + Lvote
 ```
 ### Linear Leios transitions
 The relation describing the transition given input and state
@@ -216,6 +231,18 @@ Note: Submitted data to the base chain is only taken into account
          ∙ u ≢ Base
          ──────────────────────────────────────────────────
          s -⟦ (ϵ ⊗R) ⊗R ↑ᵢ SLOT / nothing ⟧⇀ addUpkeep s u
+
+  -- Deferral of the VT-Role (CIP-0164 voting window): abstaining from voting
+  -- is permitted while the current EB's voting window is still open
+  -- (`slot < voteDeadline`), even when a positive VT-Role step could fire.
+  -- Together with `Roles₂` this yields bounded liveness: at the deadline slot
+  -- neither `Roles₃` (window closes) nor `Roles₂` (a vote can still fire)
+  -- applies, so a vote must be cast by then.
+  Roles₃ : let open LeiosState s in
+         ∙ slot < voteDeadline s
+         ∙ needsUpkeep VT-Role
+         ──────────────────────────────────────────────────
+         s -⟦ (ϵ ⊗R) ⊗R ↑ᵢ SLOT / nothing ⟧⇀ addUpkeep s VT-Role
 ```
 <!--
 ```agda
@@ -312,5 +339,6 @@ instance
     (_ , VT-Role _ , x) → Base≢VT-Role (∷-injectiveˡ (trans x refl))
 
 unquoteDecl Roles₂-premises = genPremises Roles₂-premises (quote Roles₂)
+unquoteDecl Roles₃-premises = genPremises Roles₃-premises (quote Roles₃)
 ```
 -->

--- a/formal-spec/Leios/Linear.lagda.md
+++ b/formal-spec/Leios/Linear.lagda.md
@@ -140,9 +140,16 @@ mempool.
           ∙ EndorserBlockOSig.txs eb ≢ []
           ∙ needsUpkeep VT-Role
           ∙ inVotingCommittee params (stake s)
+          -- Only a pool with a registered voting key may sign (CIP-0164,
+          -- "Key Registration and Rotation"): a pool selected by stake
+          -- without a registered key holds a *keyless* committee seat and
+          -- must abstain.
+          ∙ id ∈ˡ L.map poolID PubKeys
           ───────────────────────────────────────────────────────
           s ↝ ( rememberVote (addUpkeep s VT-Role) eb
-              , Send (vtHeader [ vote sk-VT (hash eb) ]) nothing)
+              -- the vote signs the hash of the announcing RB (CIP-0164,
+              -- "Vote Structure")
+              , Send (vtHeader [ vote sk-VT (hash currentRB) ]) nothing)
 ```
 Predicate needed for slot transition. Special care needs to be taken when starting from
 genesis.
@@ -343,7 +350,7 @@ instance
       in just≢nothing $ trans (sym y) (subst (not-found s) (sym ji) eq₃)
   ... | just (slot' , eb)
     with ¿ VT-Role-premises {s} {eb} {ebHash} {slot'} .proj₁ ¿
-  ... | yes p = yes ((rememberVote (addUpkeep s VT-Role) eb , Send (vtHeader [ vote sk-VT (hash eb) ]) nothing) ,
+  ... | yes p = yes ((rememberVote (addUpkeep s VT-Role) eb , Send (vtHeader [ vote sk-VT (hash (LeiosState.currentRB s)) ]) nothing) ,
                       VT-Role p , refl)
   ... | no ¬p = no λ where (_ , VT-Role (x , y , p) , _) → ¬p $ subst
                              (λ where (eb , ebHash , slot) → VT-Role-premises {s} {eb} {ebHash} {slot} .proj₁)

--- a/formal-spec/Leios/Linear.lagda.md
+++ b/formal-spec/Leios/Linear.lagda.md
@@ -238,6 +238,16 @@ Note: Submitted data to the base chain is only taken into account
   -- Together with `Roles₂` this yields bounded liveness: at the deadline slot
   -- neither `Roles₃` (window closes) nor `Roles₂` (a vote can still fire)
   -- applies, so a vote must be cast by then.
+  --
+  -- Note the deadline forces a vote only if a VT-Role step is still possible.
+  -- In particular, a vote provided earlier in the window does not get forced
+  -- again: `rememberVote` records the EB in `VotedEBs`, which persists in
+  -- 'LeiosState' (unlike the per-slot `Upkeep`), so VT-Role's
+  -- `hash eb ∉ VotedEBs` premise blocks any re-vote and `Roles₂` then licenses
+  -- abstention at and after the deadline. The same holds when no vote step
+  -- ever becomes possible (ineligible, EB received after `Lhdr`, invalid or
+  -- empty EB): abstention goes through `Roles₂` at every slot; `Roles₃` is
+  -- only needed while an eligible voter is still deliberating.
   Roles₃ : let open LeiosState s in
          ∙ slot < voteDeadline s
          ∙ needsUpkeep VT-Role

--- a/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
@@ -186,7 +186,7 @@ data Err-verifyStep (σ : Action) (i : FFDT Out ⊎ BaseIOF In ⊎ IOT In) (s : 
     isValidityChecked slot eb ×
     EndorserBlockOSig.txs eb ≢ [] ×
     needsUpkeep VT-Role ×
-    inVotingCommittee sk-VT (stake s)) →
+    inVotingCommittee params (stake s)) →
     Err-verifyStep σ i s
   Err-AllDone : ¬ (allDone s) → Err-verifyStep σ i s
   Err-BaseUpkeep : ¬ (LeiosState.needsUpkeep s Base) → Err-verifyStep σ i s
@@ -405,7 +405,7 @@ module _
       with ¿ LeiosState.needsUpkeep s VT-Role ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: VT-Role already done" (LeiosState.slot s)
     ... | yes p
-      with ¿ inVotingCommittee sk-VT (stake s) ¿
+      with ¿ inVotingCommittee params (stake s) ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: Not in the voting committee" (LeiosState.slot s)
     ... | yes p = printf "%u : Impossible!" (LeiosState.slot s)
 

--- a/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
@@ -68,6 +68,7 @@ getAction (Roles₁ (VT-Role {s} {eb = eb} {slot' = slot'} _)) = VT-Role-Action 
 getAction (Roles₂ {u = Base} (_ , _ , x))                    = ⊥-elim (x refl) -- Roles₂ excludes the `Base` role
 getAction (Roles₂ {s} {u = EB-Role} _)                       = No-EB-Role-Action (LeiosState.slot s)
 getAction (Roles₂ {s} {u = VT-Role} _)                       = No-VT-Role-Action (LeiosState.slot s)
+getAction (Roles₃ {s} _)                                     = No-VT-Role-Action (LeiosState.slot s)
 ```
 ```agda
 getSlot : Action → ℕ
@@ -181,11 +182,11 @@ data Err-verifyStep (σ : Action) (i : FFDT Out ⊎ BaseIOF In ⊎ IOT In) (s : 
     isValid s (inj₁ (ebHeader eb)) ×
     slot' ≤ slotNumber eb + Lhdr ×
     slotNumber eb + 3 * Lhdr ≤ slot ×
-    slot ≡ slotNumber eb + (3 * Lhdr ⊔ validityCheckTime eb) ×
+    slot ≤ slotNumber eb + 3 * Lhdr + Lvote ×
     validityCheckTime eb ≤ 3 * Lhdr + Lvote ×
     EndorserBlockOSig.txs eb ≢ [] ×
     needsUpkeep VT-Role ×
-    canProduceV (slotNumber eb) sk-VT (stake s)) →
+    inVotingCommittee sk-VT (stake s)) →
     Err-verifyStep σ i s
   Err-AllDone : ¬ (allDone s) → Err-verifyStep σ i s
   Err-BaseUpkeep : ¬ (LeiosState.needsUpkeep s Base) → Err-verifyStep σ i s
@@ -307,9 +308,10 @@ verifyStep' (No-EB-Role-Action _) (inj₁ FTCH) _ _        = Err (Err-InputMisma
 verifyStep' (No-EB-Role-Action _) (inj₁ (FFD-OUT _)) _ _ = Err (Err-InputMismatch λ ())
 verifyStep' (No-EB-Role-Action _) (inj₂ y) _ _           = Err (Err-InputMismatch (inj₂≢SLOT y))
 verifyStep' (No-VT-Role-Action _) (inj₁ SLOT) s refl
-  with ¿ Roles₂-premises {s = s} {u = VT-Role} .proj₁ ¿
-... | yes p = Ok' (Roles₂ p)
-... | no ¬p = Err (Err-Roles₂-premises ¬p)
+  with ¿ Roles₂-premises {s = s} {u = VT-Role} .proj₁ ¿ | ¿ Roles₃-premises {s = s} .proj₁ ¿
+... | yes p | _     = Ok' (Roles₂ p)
+... | no _  | yes q = Ok' (Roles₃ q)
+... | no ¬p | no _  = Err (Err-Roles₂-premises ¬p)
 verifyStep' (No-VT-Role-Action _) (inj₁ FTCH) _ _        = Err (Err-InputMismatch λ ())
 verifyStep' (No-VT-Role-Action _) (inj₁ (FFD-OUT _)) _ _ = Err (Err-InputMismatch λ ())
 verifyStep' (No-VT-Role-Action _) (inj₂ y) _ _           = Err (Err-InputMismatch (inj₂≢SLOT y))
@@ -391,8 +393,8 @@ module _
       with ¿ slotNumber eb + 3 * Lhdr ≤ (LeiosState.slot s) ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: ¬ (slotNumber eb + 3 * Lhdr ≤ (LeiosState.slot s))" (LeiosState.slot s)
     ... | yes p
-      with ¿ (LeiosState.slot s) ≡ slotNumber eb + validityCheckTime eb ¿
-    ... | no ¬p = printf "%u : Err-VT-Role-premises: ¬ ((LeiosState.slot s) ≡ slotNumber eb + validityCheckTime eb)" (LeiosState.slot s)
+      with ¿ (LeiosState.slot s) ≤ slotNumber eb + 3 * Lhdr + Lvote ¿
+    ... | no ¬p = printf "%u : Err-VT-Role-premises: ¬ ((LeiosState.slot s) ≤ slotNumber eb + 3 * Lhdr + Lvote)" (LeiosState.slot s)
     ... | yes p
       with ¿ validityCheckTime eb ≤ 3 * Lhdr + Lvote ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: ¬ (validityCheckTime eb ≤ 3 * Lhdr + Lvote)" (LeiosState.slot s)
@@ -403,8 +405,8 @@ module _
       with ¿ LeiosState.needsUpkeep s VT-Role ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: VT-Role already done" (LeiosState.slot s)
     ... | yes p
-      with ¿ canProduceV (slotNumber eb) sk-VT (stake s) ¿
-    ... | no ¬p = printf "%u : Err-VT-Role-premises: Can not produce vote" (LeiosState.slot s)
+      with ¿ inVotingCommittee sk-VT (stake s) ¿
+    ... | no ¬p = printf "%u : Err-VT-Role-premises: Not in the voting committee" (LeiosState.slot s)
     ... | yes p = printf "%u : Impossible!" (LeiosState.slot s)
 
     iErr-verifyTrace : ∀ {s} → IsError (λ t → Err-verifyTrace t s)

--- a/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
@@ -186,7 +186,8 @@ data Err-verifyStep (σ : Action) (i : FFDT Out ⊎ BaseIOF In ⊎ IOT In) (s : 
     isValidityChecked slot eb ×
     EndorserBlockOSig.txs eb ≢ [] ×
     needsUpkeep VT-Role ×
-    inVotingCommittee params (stake s)) →
+    inVotingCommittee params (stake s) ×
+    id ∈ˡ L.map poolID PubKeys) →
     Err-verifyStep σ i s
   Err-AllDone : ¬ (allDone s) → Err-verifyStep σ i s
   Err-BaseUpkeep : ¬ (LeiosState.needsUpkeep s Base) → Err-verifyStep σ i s
@@ -407,6 +408,9 @@ module _
     ... | yes p
       with ¿ inVotingCommittee params (stake s) ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: Not in the voting committee" (LeiosState.slot s)
+    ... | yes p
+      with ¿ id ∈ˡ L.map poolID (LeiosState.PubKeys s) ¿
+    ... | no ¬p = printf "%u : Err-VT-Role-premises: No registered voting key (keyless committee seat)" (LeiosState.slot s)
     ... | yes p = printf "%u : Impossible!" (LeiosState.slot s)
 
     iErr-verifyTrace : ∀ {s} → IsError (λ t → Err-verifyTrace t s)

--- a/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier.lagda.md
@@ -183,7 +183,7 @@ data Err-verifyStep (σ : Action) (i : FFDT Out ⊎ BaseIOF In ⊎ IOT In) (s : 
     slot' ≤ slotNumber eb + Lhdr ×
     slotNumber eb + 3 * Lhdr ≤ slot ×
     slot ≤ slotNumber eb + 3 * Lhdr + Lvote ×
-    validityCheckTime eb ≤ 3 * Lhdr + Lvote ×
+    isValidityChecked slot eb ×
     EndorserBlockOSig.txs eb ≢ [] ×
     needsUpkeep VT-Role ×
     inVotingCommittee sk-VT (stake s)) →
@@ -396,8 +396,8 @@ module _
       with ¿ (LeiosState.slot s) ≤ slotNumber eb + 3 * Lhdr + Lvote ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: ¬ ((LeiosState.slot s) ≤ slotNumber eb + 3 * Lhdr + Lvote)" (LeiosState.slot s)
     ... | yes p
-      with ¿ validityCheckTime eb ≤ 3 * Lhdr + Lvote ¿
-    ... | no ¬p = printf "%u : Err-VT-Role-premises: ¬ (validityCheckTime eb ≤ 3 * Lhdr + Lvote)" (LeiosState.slot s)
+      with ¿ isValidityChecked (LeiosState.slot s) eb ¿
+    ... | no ¬p = printf "%u : Err-VT-Role-premises: EB validation not completed (isValidityChecked)" (LeiosState.slot s)
     ... | yes p
       with ¿ EndorserBlockOSig.txs eb ≢ [] ¿
     ... | no ¬p = printf "%u : Err-VT-Role-premises: No transactions in EB" (LeiosState.slot s)

--- a/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
@@ -39,11 +39,7 @@ and there are the schedules for block production and voting in the field `winnin
   testParams =
     record
       { sutId = fzero
-      ; winning-slots = fromList $
-        -- Voting eligibility is the explicit CIP-0164 stake-truncation
-        -- committee (see `inVotingCommittee` in Leios.Config); winning-slots
-        -- only govern EB production.
-        108 ∷ []
+      ; winning-slots = fromList $ 108 ∷ []
       }
 ```
 #### SpecStructure

--- a/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
@@ -31,6 +31,8 @@ and there are the schedules for block production and voting in the field `winnin
       ; Lhdr = 1
       ; Lvote = 2
       ; Ldiff = 2
+      ; σc-num = 99
+      ; σc-den = 100
       }
 
   testParams : TestParams params
@@ -38,11 +40,9 @@ and there are the schedules for block production and voting in the field `winnin
     record
       { sutId = fzero
       ; winning-slots = fromList $
-        -- Voting eligibility is epoch-fixed (CIP-0164 committee): the single
-        -- (VT , 0) entry makes the SUT a committee member for the whole trace
-        -- (0 is `epochVInput` in `Test.Defaults`). EB production remains
-        -- per-slot.
-                     (VT , 0)   ∷
+        -- Voting eligibility is the explicit CIP-0164 stake-truncation
+        -- committee (see `inVotingCommittee` in Leios.Config); winning-slots
+        -- only govern EB production.
         (EB , 108) ∷
         []
       }

--- a/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
@@ -38,12 +38,12 @@ and there are the schedules for block production and voting in the field `winnin
     record
       { sutId = fzero
       ; winning-slots = fromList $
-                     (VT , 100) ∷
-                     (VT , 104) ∷
-                     (VT , 105) ∷
-                     (VT , 106) ∷
-                     (VT , 107) ∷
-        (EB , 108) ∷ (VT , 108) ∷
+        -- Voting eligibility is epoch-fixed (CIP-0164 committee): the single
+        -- (VT , 0) entry makes the SUT a committee member for the whole trace
+        -- (0 is `epochVInput` in `Test.Defaults`). EB production remains
+        -- per-slot.
+                     (VT , 0)   ∷
+        (EB , 108) ∷
         []
       }
 ```

--- a/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
+++ b/formal-spec/Leios/Linear/Trace/Verifier/Test.lagda.md
@@ -43,8 +43,7 @@ and there are the schedules for block production and voting in the field `winnin
         -- Voting eligibility is the explicit CIP-0164 stake-truncation
         -- committee (see `inVotingCommittee` in Leios.Config); winning-slots
         -- only govern EB production.
-        (EB , 108) ∷
-        []
+        108 ∷ []
       }
 ```
 #### SpecStructure

--- a/formal-spec/Leios/SpecStructure.lagda.md
+++ b/formal-spec/Leios/SpecStructure.lagda.md
@@ -65,5 +65,14 @@ record SpecStructure : Type₂ where
 ```
 ```agda
   field getEBCert         : ∀ {s eb} → isVoteCertified s eb → EBCert
-        validityCheckTime : EndorserBlock → ℕ
+        -- Whether validation of the given EB has completed by the given slot.
+        -- Replaces the former `validityCheckTime : EndorserBlock → ℕ` oracle:
+        -- validation latency is a property of the node and its environment,
+        -- not of the EB alone, so the spec only assumes an observable
+        -- completion predicate (monotone in the slot in intended
+        -- instantiations). Eventually to be provided by an asynchronous
+        -- validation functionality (Valid/Invalid/InProgress with bounded
+        -- InProgress).
+        isValidityChecked  : ℕ → EndorserBlock → Type
+        isValidityChecked? : ∀ n eb → Dec (isValidityChecked n eb)
 ```

--- a/formal-spec/Leios/SpecStructure.lagda.md
+++ b/formal-spec/Leios/SpecStructure.lagda.md
@@ -46,6 +46,10 @@ record SpecStructure : Type₂ where
 ```agda
   field B' : BaseAbstract
         BM : BaseAbstract.BaseMachine B'
+        -- Votes sign the hash of the announcing RB (CIP-0164, "Vote
+        -- Structure"): binding the vote to the announcement distinguishes
+        -- multiple RB headers announcing the same EB.
+        ⦃ Hashable-RankingBlock ⦄ : Hashable RankingBlock Hash
 
   open Leios.KeyRegistration a vrf' public
 ```

--- a/formal-spec/Leios/SpecStructure.lagda.md
+++ b/formal-spec/Leios/SpecStructure.lagda.md
@@ -46,9 +46,6 @@ record SpecStructure : Type₂ where
 ```agda
   field B' : BaseAbstract
         BM : BaseAbstract.BaseMachine B'
-        -- Votes sign the hash of the announcing RB (CIP-0164, "Vote
-        -- Structure"): binding the vote to the announcement distinguishes
-        -- multiple RB headers announcing the same EB.
         ⦃ Hashable-RankingBlock ⦄ : Hashable RankingBlock Hash
 
   open Leios.KeyRegistration a vrf' public

--- a/formal-spec/Leios/VRF.lagda.md
+++ b/formal-spec/Leios/VRF.lagda.md
@@ -37,6 +37,14 @@ record LeiosVRF : Type₁ where
   -- transforming slot numbers into VRF seeds
   field genIBInput genEBInput genVInput genV1Input genV2Input : ℕ → ℕ
 
+  -- Voting-committee seed (CIP-0164): the committee is fixed once per epoch
+  -- from the stake distribution (stake-based truncation to the σc coverage
+  -- target); there is no per-election sortition. This specification covers a
+  -- single epoch (one static stake distribution), so membership is a
+  -- slot-independent eligibility check against this fixed, epoch-level input
+  -- (see `inVotingCommittee` below).
+  field epochVInput : ℕ
+
   canProduceIB : ℕ → PrivKey → ℕ → VrfPf → Type
   canProduceIB slot k stake π = let (val , pf) = eval k (genIBInput slot) in val < stake × pf ≡ π
 
@@ -66,6 +74,14 @@ record LeiosVRF : Type₁ where
 
   Dec-canProduceV : ∀ {slot k stake} → Dec (canProduceV slot k stake)
   Dec-canProduceV {slot} {k} {stake} with eval k (genVInput slot)
+  ... | (val , pf) = ¿ val < stake ¿
+
+  -- Voting-committee membership (CIP-0164): slot-independent, epoch-fixed.
+  inVotingCommittee : PrivKey → ℕ → Type
+  inVotingCommittee k stake = proj₁ (eval k epochVInput) < stake
+
+  Dec-inVotingCommittee : ∀ {k stake} → Dec (inVotingCommittee k stake)
+  Dec-inVotingCommittee {k} {stake} with eval k epochVInput
   ... | (val , pf) = ¿ val < stake ¿
 
   canProduceV1 : ℕ → PrivKey → ℕ → Type

--- a/formal-spec/Leios/VRF.lagda.md
+++ b/formal-spec/Leios/VRF.lagda.md
@@ -37,14 +37,6 @@ record LeiosVRF : Type₁ where
   -- transforming slot numbers into VRF seeds
   field genIBInput genEBInput genVInput genV1Input genV2Input : ℕ → ℕ
 
-  -- Voting-committee seed (CIP-0164): the committee is fixed once per epoch
-  -- from the stake distribution (stake-based truncation to the σc coverage
-  -- target); there is no per-election sortition. This specification covers a
-  -- single epoch (one static stake distribution), so membership is a
-  -- slot-independent eligibility check against this fixed, epoch-level input
-  -- (see `inVotingCommittee` below).
-  field epochVInput : ℕ
-
   canProduceIB : ℕ → PrivKey → ℕ → VrfPf → Type
   canProduceIB slot k stake π = let (val , pf) = eval k (genIBInput slot) in val < stake × pf ≡ π
 
@@ -74,14 +66,6 @@ record LeiosVRF : Type₁ where
 
   Dec-canProduceV : ∀ {slot k stake} → Dec (canProduceV slot k stake)
   Dec-canProduceV {slot} {k} {stake} with eval k (genVInput slot)
-  ... | (val , pf) = ¿ val < stake ¿
-
-  -- Voting-committee membership (CIP-0164): slot-independent, epoch-fixed.
-  inVotingCommittee : PrivKey → ℕ → Type
-  inVotingCommittee k stake = proj₁ (eval k epochVInput) < stake
-
-  Dec-inVotingCommittee : ∀ {k stake} → Dec (inVotingCommittee k stake)
-  Dec-inVotingCommittee {k} {stake} with eval k epochVInput
   ... | (val , pf) = ¿ val < stake ¿
 
   canProduceV1 : ℕ → PrivKey → ℕ → Type

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -227,6 +227,10 @@ instance
   hpe : Hashable PreEndorserBlock Hash
   hpe .hash = EndorserBlockOSig.txs
 
+  -- Votes sign the announcing RB's hash: slot plus announced-EB payload.
+  hrb : Hashable RankingBlock Hash
+  hrb .hash rb = RankingBlock.slot rb ∷ maybe (λ x → x) [] (RankingBlock.announcedEB rb)
+
 record FFDBuffers : Type where
   field inEBs : List EndorserBlock
         inVTs : List (List Vote)
@@ -310,6 +314,7 @@ d-SpecStructure : SpecStructure
 d-SpecStructure = record
       { a                         = d-Abstract
       ; Hashable-PreEndorserBlock = hpe
+      ; Hashable-RankingBlock     = hrb
       ; id                        = sutId
       ; FFD'                      = d-FFDFunctionality
       ; vrf'                      = d-VRF

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -69,8 +69,8 @@ open import Leios.VRF d-Abstract public
 sutStake : ℕ
 sutStake = TotalMap.lookup stakeDistribution sutId
 
-sortition : BlockType → ℕ → ℕ
-sortition b n with (b , n) ∈? winning-slots
+sortition : ℕ → ℕ
+sortition n with n ∈? winning-slots
 ... | yes _ = 0
 ... | no _ = sutStake
 
@@ -81,7 +81,7 @@ d-VRF =
     ; vrf        =
         record
           { isKeyPair = λ _ _ → ⊤
-          ; eval      = λ (b , _) y → sortition b y , tt
+          ; eval      = λ _ y → sortition y , tt
           ; verify    = λ _ _ _ _ → ⊤
           ; verify?   = λ _ _ _ _ → yes tt
           }

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -324,5 +324,8 @@ d-SpecStructure = record
       ; KF                        = d-KeyRegistrationFunctionality
       ; va                        = d-VotingAbstract
       ; getEBCert                 = λ _ → []
-      ; validityCheckTime          = λ _ → 4
+      -- Validation is not modelled in the test defaults: every EB counts as
+      -- checked at every slot.
+      ; isValidityChecked          = λ _ _ → ⊤
+      ; isValidityChecked?         = λ _ _ → yes tt
       }

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -90,7 +90,6 @@ d-VRF =
     ; genVInput  = id
     ; genV1Input = id
     ; genV2Input = id
-    ; epochVInput = 0
     ; poolID     = proj₁
     ; verifySig  = λ _ _ → ⊤
     ; verifySig? = λ _ _ → yes tt

--- a/formal-spec/Test/Defaults.agda
+++ b/formal-spec/Test/Defaults.agda
@@ -90,6 +90,7 @@ d-VRF =
     ; genVInput  = id
     ; genV1Input = id
     ; genV2Input = id
+    ; epochVInput = 0
     ; poolID     = proj₁
     ; verifySig  = λ _ _ → ⊤
     ; verifySig? = λ _ _ → yes tt


### PR DESCRIPTION
* Voting committee selected by stake truncation predicate
* Replaced `validityCheckTime` by the predicate `isValdityChecked` (to be implemented as functionality in the categorical crypto setup later)